### PR TITLE
feat: add linear-queue-intake hook (AGE-90)

### DIFF
--- a/hooks/linear-queue-intake/HOOK.md
+++ b/hooks/linear-queue-intake/HOOK.md
@@ -14,7 +14,7 @@ Triggered by Linear plugin notification dispatch (consolidated message from `for
 ## Behavior
 
 1. Parses consolidated notification messages into structured queue items
-2. Assigns priority: `issue.assigned` (priority 1) > `comment.mention` (priority 2)
+2. Assigns priority: `issue.assigned` (1) > `issue.reassigned` (2) > `comment.mention` (3) > `issue.unassigned` (4)
 3. Deduplicates by `issueId + event` against existing queue
 4. Appends new items with status `pending`
 5. Writes queue file atomically (read → modify → write)

--- a/hooks/linear-queue-intake/HOOK.md
+++ b/hooks/linear-queue-intake/HOOK.md
@@ -1,0 +1,22 @@
+# linear-queue-intake
+
+📥 Deterministic notification parsing into work queue.
+
+## Events
+
+Triggered by Linear plugin notification dispatch (consolidated message from `formatConsolidatedMessage`).
+
+## Requirements
+
+- Workspace directory configured
+- `queue/work-queue.json` path relative to workspace
+
+## Behavior
+
+1. Parses consolidated notification messages into structured queue items
+2. Assigns priority: `issue.assigned` (priority 1) > `comment.mention` (priority 2)
+3. Deduplicates by `issueId + event` against existing queue
+4. Appends new items with status `pending`
+5. Writes queue file atomically (read → modify → write)
+
+**No LLM calls** — purely deterministic parsing.

--- a/hooks/linear-queue-intake/handler.test.ts
+++ b/hooks/linear-queue-intake/handler.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import handleIntake, { parseNotificationMessage, type WorkQueue } from "./handler.js";
+
+describe("parseNotificationMessage", () => {
+  it("parses single assigned notification", () => {
+    const result = parseNotificationMessage("Assigned to issue ENG-42: Fix login bug");
+    expect(result).toEqual([
+      { id: "ENG-42", event: "issue.assigned", summary: "Fix login bug" },
+    ]);
+  });
+
+  it("parses multi-notification message", () => {
+    const msg = `You have 3 new Linear notifications:
+
+1. [Assigned] ENG-42: Fix login bug
+2. [Mentioned] ENG-43: "Can you review this?"
+3. [Reassigned] ENG-44: Update API docs
+
+Review and prioritize before starting work.`;
+
+    const result = parseNotificationMessage(msg);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ id: "ENG-42", event: "issue.assigned", summary: "Fix login bug" });
+    expect(result[1]).toEqual({ id: "ENG-43", event: "comment.mention", summary: "Can you review this?" });
+    expect(result[2]).toEqual({ id: "ENG-44", event: "issue.reassigned", summary: "Update API docs" });
+  });
+});
+
+describe("handleIntake", () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "queue-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("creates queue file and adds 3 items from multi-notification", () => {
+    const msg = `You have 3 new Linear notifications:
+
+1. [Assigned] ENG-42: Fix login bug
+2. [Mentioned] ENG-43: Review PR
+3. [Reassigned] ENG-44: Update docs
+
+Review and prioritize before starting work.`;
+
+    const added = handleIntake(msg, workDir);
+    expect(added).toBe(3);
+
+    const queue: WorkQueue = JSON.parse(
+      readFileSync(join(workDir, "queue", "work-queue.json"), "utf-8"),
+    );
+    expect(queue.items).toHaveLength(3);
+    // Sorted by priority: assigned (1) < reassigned (2) < mentioned (3)
+    expect(queue.items[0].id).toBe("ENG-42");
+    expect(queue.items[0].priority).toBe(1);
+    expect(queue.items[1].id).toBe("ENG-44");
+    expect(queue.items[1].priority).toBe(2);
+    expect(queue.items[2].id).toBe("ENG-43");
+    expect(queue.items[2].priority).toBe(3);
+  });
+
+  it("deduplicates same issue + event across batches", () => {
+    const msg1 = "Assigned to issue ENG-42: Fix login bug";
+    const msg2 = "Assigned to issue ENG-42: Fix login bug";
+
+    handleIntake(msg1, workDir);
+    const added = handleIntake(msg2, workDir);
+
+    expect(added).toBe(0);
+
+    const queue: WorkQueue = JSON.parse(
+      readFileSync(join(workDir, "queue", "work-queue.json"), "utf-8"),
+    );
+    expect(queue.items).toHaveLength(1);
+  });
+
+  it("adds only new items when mix of new and existing", () => {
+    // First batch
+    handleIntake("Assigned to issue ENG-42: Fix login bug", workDir);
+
+    // Second batch with mix
+    const msg = `You have 2 new Linear notifications:
+
+1. [Assigned] ENG-42: Fix login bug
+2. [Assigned] ENG-50: New feature
+
+Review and prioritize before starting work.`;
+
+    const added = handleIntake(msg, workDir);
+    expect(added).toBe(1);
+
+    const queue: WorkQueue = JSON.parse(
+      readFileSync(join(workDir, "queue", "work-queue.json"), "utf-8"),
+    );
+    expect(queue.items).toHaveLength(2);
+  });
+
+  it("creates queue directory and file when they don't exist", () => {
+    const added = handleIntake("Assigned to issue ENG-42: Fix login bug", workDir);
+    expect(added).toBe(1);
+
+    const queue: WorkQueue = JSON.parse(
+      readFileSync(join(workDir, "queue", "work-queue.json"), "utf-8"),
+    );
+    expect(queue.items).toHaveLength(1);
+    expect(queue.items[0].status).toBe("pending");
+    expect(queue.items[0].startedAt).toBeNull();
+    expect(queue.items[0].completedAt).toBeNull();
+  });
+});

--- a/hooks/linear-queue-intake/handler.ts
+++ b/hooks/linear-queue-intake/handler.ts
@@ -1,0 +1,184 @@
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+
+export interface QueueItem {
+  id: string;
+  issueId: string;
+  event: string;
+  summary: string;
+  status: "pending" | "in_progress" | "done";
+  priority: number;
+  addedAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+export interface WorkQueue {
+  items: QueueItem[];
+}
+
+const EVENT_PRIORITY: Record<string, number> = {
+  "issue.assigned": 1,
+  "issue.reassigned": 2,
+  "comment.mention": 3,
+  "issue.unassigned": 4,
+};
+
+/**
+ * Parse a single notification line into a partial queue item.
+ * Handles both formats:
+ *   - Single: "Assigned to issue ENG-42: Fix login bug"
+ *   - Multi:  "1. [Assigned] ENG-42: Fix login bug"
+ */
+function parseNotificationLine(line: string): { id: string; event: string; summary: string } | null {
+  // Multi-notification format: "N. [Label] TEAM-123: summary"
+  const multiMatch = line.match(
+    /^\d+\.\s+\[(\w+(?:\s+\w+)?)\]\s+([A-Z]+-\d+):\s*(.+)$/,
+  );
+  if (multiMatch) {
+    const [, label, id, summary] = multiMatch;
+    const event = labelToEvent(label);
+    return { id, event, summary: summary.trim() };
+  }
+
+  // Multi-notification with quoted comment: "N. [Mentioned] TEAM-123: "comment text""
+  const mentionMatch = line.match(
+    /^\d+\.\s+\[Mentioned\]\s+([A-Z]+-\d+):\s*"(.+)"$/,
+  );
+  if (mentionMatch) {
+    const [, id, summary] = mentionMatch;
+    return { id, event: "comment.mention", summary: summary.trim() };
+  }
+
+  // Single notification: "Assigned to issue TEAM-123: summary"
+  const assignedMatch = line.match(/^Assigned to issue ([A-Z]+-\d+):\s*(.+)$/);
+  if (assignedMatch) {
+    return { id: assignedMatch[1], event: "issue.assigned", summary: assignedMatch[2].trim() };
+  }
+
+  // Single: "Unassigned from issue TEAM-123: summary"
+  const unassignedMatch = line.match(/^Unassigned from issue ([A-Z]+-\d+):\s*(.+)$/);
+  if (unassignedMatch) {
+    return { id: unassignedMatch[1], event: "issue.unassigned", summary: unassignedMatch[2].trim() };
+  }
+
+  // Single: "Reassigned away from issue TEAM-123: summary"
+  const reassignedMatch = line.match(/^Reassigned away from issue ([A-Z]+-\d+):\s*(.+)$/);
+  if (reassignedMatch) {
+    return { id: reassignedMatch[1], event: "issue.reassigned", summary: reassignedMatch[2].trim() };
+  }
+
+  // Single: "Mentioned in comment on issue TEAM-123: summary\n\n> body"
+  const mentionedMatch = line.match(/^Mentioned in comment on issue ([A-Z]+-\d+):\s*(.+?)(?:\n|$)/);
+  if (mentionedMatch) {
+    return { id: mentionedMatch[1], event: "comment.mention", summary: mentionedMatch[2].trim() };
+  }
+
+  return null;
+}
+
+function labelToEvent(label: string): string {
+  const map: Record<string, string> = {
+    Assigned: "issue.assigned",
+    Unassigned: "issue.unassigned",
+    Reassigned: "issue.reassigned",
+    Mentioned: "comment.mention",
+  };
+  return map[label] ?? `unknown.${label.toLowerCase()}`;
+}
+
+/**
+ * Parse a consolidated notification message into queue item candidates.
+ */
+export function parseNotificationMessage(
+  message: string,
+): Array<{ id: string; event: string; summary: string }> {
+  const results: Array<{ id: string; event: string; summary: string }> = [];
+
+  // Check if multi-notification format
+  if (message.startsWith("You have ")) {
+    const lines = message.split("\n").filter((l) => l.trim());
+    for (const line of lines) {
+      const parsed = parseNotificationLine(line.trim());
+      if (parsed) results.push(parsed);
+    }
+  } else {
+    // Single notification
+    const parsed = parseNotificationLine(message.trim());
+    if (parsed) results.push(parsed);
+  }
+
+  return results;
+}
+
+function readQueue(queuePath: string): WorkQueue {
+  if (!existsSync(queuePath)) {
+    return { items: [] };
+  }
+  try {
+    const data = readFileSync(queuePath, "utf-8");
+    return JSON.parse(data) as WorkQueue;
+  } catch {
+    return { items: [] };
+  }
+}
+
+function writeQueue(queuePath: string, queue: WorkQueue): void {
+  const dir = dirname(queuePath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(queuePath, JSON.stringify(queue, null, 2) + "\n", "utf-8");
+}
+
+/**
+ * Process a consolidated notification message and append new items to the work queue.
+ * Returns the number of new items added.
+ */
+export default function handleIntake(
+  message: string,
+  workspaceDir: string,
+): number {
+  const queuePath = join(workspaceDir, "queue", "work-queue.json");
+  const parsed = parseNotificationMessage(message);
+
+  if (parsed.length === 0) return 0;
+
+  const queue = readQueue(queuePath);
+
+  const existingKeys = new Set(
+    queue.items.map((item) => `${item.issueId ?? item.id}:${item.event}`),
+  );
+
+  let added = 0;
+  const now = new Date().toISOString();
+
+  for (const entry of parsed) {
+    const dedupKey = `${entry.id}:${entry.event}`;
+    if (existingKeys.has(dedupKey)) continue;
+
+    const item: QueueItem = {
+      id: entry.id,
+      issueId: entry.id, // Use ticket ID as issueId when UUID not available from message
+      event: entry.event,
+      summary: entry.summary,
+      status: "pending",
+      priority: EVENT_PRIORITY[entry.event] ?? 5,
+      addedAt: now,
+      startedAt: null,
+      completedAt: null,
+    };
+
+    queue.items.push(item);
+    existingKeys.add(dedupKey);
+    added++;
+  }
+
+  if (added > 0) {
+    // Sort by priority (lower = higher priority)
+    queue.items.sort((a, b) => a.priority - b.priority);
+    writeQueue(queuePath, queue);
+  }
+
+  return added;
+}

--- a/hooks/linear-queue-intake/handler.ts
+++ b/hooks/linear-queue-intake/handler.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync, openSync, writeSync, fsyncSync, closeSync, unlinkSync } from "node:fs";
 import { join, dirname } from "node:path";
 
 export interface QueueItem {
@@ -31,6 +31,16 @@ const EVENT_PRIORITY: Record<string, number> = {
  *   - Multi:  "1. [Assigned] ENG-42: Fix login bug"
  */
 function parseNotificationLine(line: string): { id: string; event: string; summary: string } | null {
+  // Multi-notification with quoted comment: "N. [Mentioned] TEAM-123: "comment text""
+  // Must be checked before multiMatch since multiMatch would also match Mentioned lines
+  const mentionMatch = line.match(
+    /^\d+\.\s+\[Mentioned\]\s+([A-Z]+-\d+):\s*"(.+)"$/,
+  );
+  if (mentionMatch) {
+    const [, id, summary] = mentionMatch;
+    return { id, event: "comment.mention", summary: summary.trim() };
+  }
+
   // Multi-notification format: "N. [Label] TEAM-123: summary"
   const multiMatch = line.match(
     /^\d+\.\s+\[(\w+(?:\s+\w+)?)\]\s+([A-Z]+-\d+):\s*(.+)$/,
@@ -39,15 +49,6 @@ function parseNotificationLine(line: string): { id: string; event: string; summa
     const [, label, id, summary] = multiMatch;
     const event = labelToEvent(label);
     return { id, event, summary: summary.trim() };
-  }
-
-  // Multi-notification with quoted comment: "N. [Mentioned] TEAM-123: "comment text""
-  const mentionMatch = line.match(
-    /^\d+\.\s+\[Mentioned\]\s+([A-Z]+-\d+):\s*"(.+)"$/,
-  );
-  if (mentionMatch) {
-    const [, id, summary] = mentionMatch;
-    return { id, event: "comment.mention", summary: summary.trim() };
   }
 
   // Single notification: "Assigned to issue TEAM-123: summary"
@@ -128,7 +129,21 @@ function writeQueue(queuePath: string, queue: WorkQueue): void {
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
-  writeFileSync(queuePath, JSON.stringify(queue, null, 2) + "\n", "utf-8");
+  const tmpPath = `${queuePath}.tmp.${process.pid}.${Date.now()}`;
+  const content = JSON.stringify(queue, null, 2) + "\n";
+  try {
+    const fd = openSync(tmpPath, "w");
+    try {
+      writeSync(fd, content, 0, "utf-8");
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+    renameSync(tmpPath, queuePath);
+  } catch (err) {
+    try { unlinkSync(tmpPath); } catch { /* ignore cleanup errors */ }
+    throw err;
+  }
 }
 
 /**


### PR DESCRIPTION
Deterministic notification parsing into persistent work queue.

## What
- Parses consolidated Linear notification messages into structured queue items
- Assigns priority: assigned (1) > reassigned (2) > mentioned (3) > unassigned (4)
- Deduplicates by issueId + event type
- Atomic file writes to queue/work-queue.json

## Files
- `hooks/linear-queue-intake/HOOK.md` — hook metadata
- `hooks/linear-queue-intake/handler.ts` — handler implementation
- `hooks/linear-queue-intake/handler.test.ts` — test suite

Closes AGE-90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a notification queue intake that parses consolidated plugin messages, prioritizes events, deduplicates by issue and event, and appends pending items with atomic state updates.

* **Documentation**
  * Added docs describing the intake process, event mapping, requirements, and deduplication behavior.

* **Tests**
  * Added tests for message parsing, priority ordering, deduplication, queue persistence, and creation of queue state when missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->