### PR TITLE
feat: add linear-queue-recovery hook (AGE-91)

### DIFF
--- a/hooks/linear-queue-recovery/HOOK.md
+++ b/hooks/linear-queue-recovery/HOOK.md
@@ -1,0 +1,22 @@
+# linear-queue-recovery
+
+🔄 Reset stale queue items on gateway startup.
+
+## Events
+
+- `gateway:startup`
+
+## Requirements
+
+- Workspace directory configured
+- `queue/work-queue.json` path relative to workspace
+
+## Behavior
+
+1. Reads `queue/work-queue.json` (no-op if missing)
+2. Finds items with status `in_progress`
+3. Resets them to `pending` (clears `startedAt`)
+4. Logs recovery actions
+5. Writes updated queue file
+
+Ensures no tasks get stuck after crashes or restarts.

--- a/hooks/linear-queue-recovery/handler.test.ts
+++ b/hooks/linear-queue-recovery/handler.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import handleRecovery, { type WorkQueue } from "./handler.js";
+
+function writeQueue(workDir: string, queue: WorkQueue): void {
+  const dir = join(workDir, "queue");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "work-queue.json"), JSON.stringify(queue, null, 2), "utf-8");
+}
+
+function readQueue(workDir: string): WorkQueue {
+  return JSON.parse(readFileSync(join(workDir, "queue", "work-queue.json"), "utf-8"));
+}
+
+const makeItem = (overrides: Partial<import("./handler.js").QueueItem> = {}): import("./handler.js").QueueItem => ({
+  id: "ENG-1",
+  issueId: "uuid-1",
+  event: "issue.assigned",
+  summary: "Test item",
+  status: "pending",
+  priority: 1,
+  addedAt: "2026-02-14T00:00:00.000Z",
+  startedAt: null,
+  completedAt: null,
+  ...overrides,
+});
+
+describe("handleRecovery", () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "recovery-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("resets in_progress items to pending", () => {
+    writeQueue(workDir, {
+      items: [
+        makeItem({ id: "ENG-1", status: "in_progress", startedAt: "2026-02-14T10:00:00.000Z" }),
+        makeItem({ id: "ENG-2", status: "pending" }),
+        makeItem({ id: "ENG-3", status: "pending" }),
+      ],
+    });
+
+    const recovered = handleRecovery(workDir);
+    expect(recovered).toBe(1);
+
+    const queue = readQueue(workDir);
+    expect(queue.items[0].status).toBe("pending");
+    expect(queue.items[0].startedAt).toBeNull();
+    expect(queue.items[1].status).toBe("pending");
+    expect(queue.items[2].status).toBe("pending");
+  });
+
+  it("does nothing when all items are done", () => {
+    writeQueue(workDir, {
+      items: [
+        makeItem({ id: "ENG-1", status: "done", completedAt: "2026-02-14T12:00:00.000Z" }),
+        makeItem({ id: "ENG-2", status: "done", completedAt: "2026-02-14T12:00:00.000Z" }),
+      ],
+    });
+
+    const recovered = handleRecovery(workDir);
+    expect(recovered).toBe(0);
+  });
+
+  it("no-ops when queue file does not exist", () => {
+    const recovered = handleRecovery(workDir);
+    expect(recovered).toBe(0);
+  });
+
+  it("no-ops when items array is empty", () => {
+    writeQueue(workDir, { items: [] });
+
+    const recovered = handleRecovery(workDir);
+    expect(recovered).toBe(0);
+  });
+});

--- a/hooks/linear-queue-recovery/handler.ts
+++ b/hooks/linear-queue-recovery/handler.ts
@@ -1,0 +1,60 @@
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+export interface QueueItem {
+  id: string;
+  issueId: string;
+  event: string;
+  summary: string;
+  status: "pending" | "in_progress" | "done";
+  priority: number;
+  addedAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+export interface WorkQueue {
+  items: QueueItem[];
+}
+
+/**
+ * Reset stale in_progress queue items to pending on gateway startup.
+ * Returns the number of items recovered.
+ */
+export default function handleRecovery(workspaceDir: string): number {
+  const queuePath = join(workspaceDir, "queue", "work-queue.json");
+
+  if (!existsSync(queuePath)) {
+    return 0;
+  }
+
+  let queue: WorkQueue;
+  try {
+    const data = readFileSync(queuePath, "utf-8");
+    queue = JSON.parse(data) as WorkQueue;
+  } catch {
+    return 0;
+  }
+
+  if (!queue.items || queue.items.length === 0) {
+    return 0;
+  }
+
+  let recovered = 0;
+
+  for (const item of queue.items) {
+    if (item.status === "in_progress") {
+      console.log(`[linear-queue-recovery] Resetting stale item ${item.id} (${item.summary}) to pending`);
+      item.status = "pending";
+      item.startedAt = null;
+      recovered++;
+    }
+  }
+
+  if (recovered > 0) {
+    writeFileSync(queuePath, JSON.stringify(queue, null, 2) + "\n", "utf-8");
+    console.log(`[linear-queue-recovery] Recovered ${recovered} stale item(s)`);
+  }
+
+  return recovered;
+}

--- a/hooks/linear-queue-recovery/handler.ts
+++ b/hooks/linear-queue-recovery/handler.ts
@@ -1,5 +1,5 @@
-import { readFileSync, writeFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { readFileSync, writeFileSync, existsSync, renameSync, openSync, writeSync, fsyncSync, closeSync, unlinkSync } from "node:fs";
+import { join, dirname } from "node:path";
 
 export interface QueueItem {
   id: string;
@@ -36,7 +36,7 @@ export default function handleRecovery(workspaceDir: string): number {
     return 0;
   }
 
-  if (!queue.items || queue.items.length === 0) {
+  if (!Array.isArray(queue.items) || queue.items.length === 0) {
     return 0;
   }
 
@@ -52,7 +52,21 @@ export default function handleRecovery(workspaceDir: string): number {
   }
 
   if (recovered > 0) {
-    writeFileSync(queuePath, JSON.stringify(queue, null, 2) + "\n", "utf-8");
+    const content = JSON.stringify(queue, null, 2) + "\n";
+    const tmpPath = `${queuePath}.tmp.${process.pid}.${Date.now()}`;
+    try {
+      const fd = openSync(tmpPath, "w");
+      try {
+        writeSync(fd, content, 0, "utf-8");
+        fsyncSync(fd);
+      } finally {
+        closeSync(fd);
+      }
+      renameSync(tmpPath, queuePath);
+    } catch (err) {
+      try { unlinkSync(tmpPath); } catch { /* ignore cleanup errors */ }
+      throw err;
+    }
     console.log(`[linear-queue-recovery] Recovered ${recovered} stale item(s)`);
   }
 


### PR DESCRIPTION
Reset stale in_progress queue items on gateway startup.

## What
- Runs on gateway:startup event
- Finds items with status in_progress and resets to pending
- Clears startedAt timestamp
- No-op when queue file missing or empty

## Files
- `hooks/linear-queue-recovery/HOOK.md` — hook metadata
- `hooks/linear-queue-recovery/handler.ts` — handler implementation
- `hooks/linear-queue-recovery/handler.test.ts` — test suite

Closes AGE-91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic work-queue recovery on gateway startup to reset and retry tasks stuck in progress, preventing lost or stuck work after crashes or restarts.

* **Documentation**
  * Added user-facing documentation describing the recovery behavior and configuration requirements.

* **Tests**
  * Added comprehensive tests covering recovery behavior and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->