### PR TITLE
fix: resolve name-based agentMapping keys to Linear user UUIDs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,14 @@ import { createWebhookHandler } from "./webhook-handler.js";
 import { createEventRouter, type RouterAction } from "./event-router.js";
 import { InboxQueue, type EnqueueEntry } from "./work-queue.js";
 import { createQueueTool } from "./tools/queue-tool.js";
-import { setApiKey } from "./linear-api.js";
+import { setApiKey, resolveUserId } from "./linear-api.js";
 import { createIssueTool } from "./tools/linear-issue-tool.js";
 import { createCommentTool } from "./tools/linear-comment-tool.js";
 import { createTeamTool } from "./tools/linear-team-tool.js";
 import { createProjectTool } from "./tools/linear-project-tool.js";
 import { createRelationTool } from "./tools/linear-relation-tool.js";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 const CHANNEL_ID = "linear";
 const DEFAULT_DEBOUNCE_MS = 30_000;
@@ -144,10 +146,47 @@ export function activate(api: OpenClawPluginApi): void {
     return;
   }
 
-  const agentMapping =
+  const rawAgentMapping =
     (api.pluginConfig?.["agentMapping"] as Record<string, string>) ?? {};
-  if (Object.keys(agentMapping).length === 0) {
+  if (Object.keys(rawAgentMapping).length === 0) {
     api.logger.info("[linear] agentMapping is empty — all events will be dropped");
+  }
+
+  // Normalize agentMapping: resolve name/email keys to Linear user UUIDs.
+  // UUID keys are kept as-is; non-UUID keys are resolved via the Linear API.
+  // Both forms end up in the final map so the event router can match by UUID.
+  const agentMapping: Record<string, string> = {};
+  const namesToResolve: Array<{ key: string; agentId: string }> = [];
+
+  for (const [key, agentId] of Object.entries(rawAgentMapping)) {
+    if (UUID_RE.test(key)) {
+      agentMapping[key] = agentId;
+    } else {
+      // Keep the name key as a fallback; also queue for UUID resolution
+      agentMapping[key] = agentId;
+      namesToResolve.push({ key, agentId });
+    }
+  }
+
+  if (namesToResolve.length > 0) {
+    // Resolve in the background so activation isn't blocked
+    Promise.all(
+      namesToResolve.map(async ({ key, agentId }) => {
+        try {
+          const uuid = await resolveUserId(key);
+          agentMapping[uuid] = agentId;
+          api.logger.info(`[linear] Resolved agentMapping key "${key}" → ${uuid}`);
+        } catch (err) {
+          api.logger.error(
+            `[linear] Failed to resolve agentMapping key "${key}": ${formatErrorMessage(err)}`,
+          );
+        }
+      }),
+    ).catch((err) => {
+      api.logger.error(
+        `[linear] agentMapping resolution failed: ${formatErrorMessage(err)}`,
+      );
+    });
   }
 
   const eventFilter =


### PR DESCRIPTION
## Problem

The event router looks up `agentMapping` by `assigneeId` (a UUID from the webhook payload), but users commonly configure agentMapping with display names:

```json
"agentMapping": { "Titus": "default" }
```

This caused all webhook events to log `Unmapped Linear user <uuid>` and silently drop — no queue items were created, no agents were woken.

## Fix

At activation time, non-UUID keys in `agentMapping` are resolved to Linear user UUIDs via `resolveUserId()`. Both the original name key and the resolved UUID are kept in the map, so either form works:

```json
// Both of these now work:
"agentMapping": { "Titus": "default" }
"agentMapping": { "ba099077-ad9a-4dd1-9527-8af170a92379": "default" }
```

Resolution happens in the background so plugin activation isn't blocked. If a name can't be resolved (e.g. typo), it's logged as an error and the name key is still kept as a fallback.

## Testing

- All 179 existing tests pass
- TypeScript compiles clean
- Deployed to live extension and restarting gateway to verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent mapping now accepts non-UUID identifiers, automatically resolving them to UUIDs in the background without blocking activation.
  * Enhanced error handling and logging for identifier resolution to improve troubleshooting visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->