### PR TITLE
feat: route Linear comment replies to parent comment author (AGE-166)

### DIFF
--- a/src/event-router.ts
+++ b/src/event-router.ts
@@ -384,10 +384,6 @@ function handleComment(
   const bodyData = event.data.bodyData;
   const mentionedIds = extractMentionedUserIds(body, bodyData, config.agentMapping);
 
-  if (mentionedIds.length === 0) {
-    return [];
-  }
-
   const actions: RouterAction[] = [];
 
   const issueRef = event.data.issue as Record<string, unknown> | undefined;
@@ -417,6 +413,35 @@ function handleComment(
       config.logger.info(
         `Unmapped Linear user ${userId} mentioned in comment on ${issueId}`,
       );
+    }
+  }
+
+  // Handle replies: route to parent comment's author
+  const parentComment = event.data.parentComment as Record<string, unknown> | undefined;
+  if (parentComment) {
+    const parentUserId = parentComment.userId as string | undefined;
+    if (parentUserId) {
+      const agentId = config.agentMapping[parentUserId];
+      // Skip if parent author was already notified via mention
+      const alreadyNotified = mentionedIds.includes(parentUserId);
+      if (agentId && !alreadyNotified) {
+        actions.push({
+          type: "wake",
+          agentId,
+          event: "comment.reply",
+          detail: `Reply to comment on issue ${issueLabel}\n\n> ${body}`,
+          issueId,
+          issueLabel,
+          identifier,
+          issuePriority,
+          linearUserId: parentUserId,
+          commentId,
+        });
+      } else if (!agentId) {
+        config.logger.info(
+          `Unmapped Linear user ${parentUserId} is parent comment author on ${issueId}`,
+        );
+      }
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ const EVENT_LABELS: Record<string, string> = {
   "issue.state_readded": "State Re-added",
   "issue.priority_changed": "Priority Changed",
   "comment.mention": "Mentioned",
+  "comment.reply": "Reply",
 };
 
 export function formatConsolidatedMessage(actions: RouterAction[]): string {
@@ -40,7 +41,7 @@ export function formatConsolidatedMessage(actions: RouterAction[]): string {
 }
 
 function formatActionSummary(action: RouterAction): string {
-  if (action.event === "comment.mention") {
+  if (action.event === "comment.mention" || action.event === "comment.reply") {
     const bodyStart = action.detail.indexOf("\n\n> ");
     if (bodyStart !== -1) {
       const quote = action.detail.slice(bodyStart + 4); // skip "\n\n> "

--- a/src/work-queue.ts
+++ b/src/work-queue.ts
@@ -27,6 +27,7 @@ export const QUEUE_EVENT: Record<string, string> = {
   "issue.assigned": "ticket",
   "issue.state_readded": "ticket",
   "comment.mention": "mention",
+  "comment.reply": "mention",
 };
 
 const REMOVAL_EVENTS = new Set([


### PR DESCRIPTION
## Summary

Linear comment replies are now added to the queue, routed to the parent comment's author with priority 0 (same as mentions).

### Changes

- **event-router.ts**: Detect replies via `parentComment.userId` and emit `comment.reply` wake action to the parent comment's author. Skips if parent author was already notified via `@mention`.
- **work-queue.ts**: Map `comment.reply` → `mention` queue event (priority 0).
- **index.ts**: Add `Reply` label for consolidated messages; handle reply events in `formatActionSummary`.

Closes AGE-166

---

**Link to Devin Session:** https://app.devin.ai/sessions/5815862042324a23bb7e26d083989b59
**Requested by:** @stepandel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users now receive notifications when someone replies to their comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->