### PR TITLE
feat: multi-workspace support with auto-detect from webhook signature

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -10,27 +10,27 @@
       "apiKey": {
         "type": "string",
         "sensitive": true,
-        "description": "Linear API key for authentication (create at linear.app/settings/account/security)"
+        "description": "Linear API key for authentication (create at linear.app/settings/account/security). Used for single-workspace mode."
       },
       "webhookSecret": {
         "type": "string",
         "sensitive": true,
-        "description": "Webhook signing secret for HMAC verification"
+        "description": "Webhook signing secret for HMAC verification. Used for single-workspace mode."
       },
       "teamIds": {
         "type": "array",
         "items": { "type": "string" },
-        "description": "Linear team keys to listen for (e.g. [\"ENG\", \"OPS\"]). Empty = all teams."
+        "description": "Linear team keys to listen for (e.g. [\"ENG\", \"OPS\"]). Empty = all teams. Used for single-workspace mode."
       },
       "eventFilter": {
         "type": "array",
         "items": { "type": "string" },
-        "description": "Event types to handle (e.g. [\"Issue\", \"Comment\"]). Empty = all types."
+        "description": "Event types to handle (e.g. [\"Issue\", \"Comment\"]). Empty = all types. Used for single-workspace mode."
       },
       "agentMapping": {
         "type": "object",
         "additionalProperties": { "type": "string" },
-        "description": "Map Linear user IDs to OpenClaw agent IDs for routing (e.g. {\"linear-user-uuid\": \"agent-name\"})"
+        "description": "Map Linear user IDs to OpenClaw agent IDs for routing (e.g. {\"linear-user-uuid\": \"agent-name\"}). Used for single-workspace mode."
       },
       "debounceMs": {
         "type": "integer",
@@ -39,9 +39,53 @@
       "stateActions": {
         "type": "object",
         "additionalProperties": { "type": "string", "enum": ["add", "remove", "ignore"] },
-        "description": "Map Linear state types or names to queue actions. Keys can be state types (triage, backlog, unstarted, started, completed, canceled) or state names (e.g. \"In Review\", \"Todo\"). Name matches take precedence over type matches (case-insensitive). Actions: add (re-add to queue), remove (remove from queue), ignore (do nothing). Defaults: backlog/unstarted=add, completed/canceled=remove, others=ignore."
+        "description": "Map Linear state types or names to queue actions. Keys can be state types (triage, backlog, unstarted, started, completed, canceled) or state names (e.g. \"In Review\", \"Todo\"). Name matches take precedence over type matches (case-insensitive). Actions: add (re-add to queue), remove (remove from queue), ignore (do nothing). Defaults: backlog/unstarted=add, completed/canceled=remove, others=ignore. Used for single-workspace mode."
+      },
+      "workspaces": {
+        "type": "array",
+        "description": "Array of workspace configurations for multi-workspace mode. When present, apiKey/webhookSecret at the top level are ignored.",
+        "items": {
+          "type": "object",
+          "required": ["id", "apiKey", "webhookSecret"],
+          "additionalProperties": false,
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Unique workspace identifier"
+            },
+            "apiKey": {
+              "type": "string",
+              "sensitive": true,
+              "description": "Linear API key for this workspace"
+            },
+            "webhookSecret": {
+              "type": "string",
+              "sensitive": true,
+              "description": "Webhook signing secret for this workspace"
+            },
+            "teamIds": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Linear team keys to listen for (e.g. [\"ENG\", \"OPS\"]). Empty = all teams."
+            },
+            "eventFilter": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Event types to handle (e.g. [\"Issue\", \"Comment\"]). Empty = all types."
+            },
+            "agentMapping": {
+              "type": "object",
+              "additionalProperties": { "type": "string" },
+              "description": "Map Linear user IDs to OpenClaw agent IDs for routing"
+            },
+            "stateActions": {
+              "type": "object",
+              "additionalProperties": { "type": "string", "enum": ["add", "remove", "ignore"] },
+              "description": "Map Linear state types or names to queue actions"
+            }
+          }
+        }
       }
-    },
-    "required": ["webhookSecret", "apiKey"]
+    }
   }
 }

--- a/src/event-router.ts
+++ b/src/event-router.ts
@@ -12,6 +12,8 @@ export type RouterAction = {
   linearUserId: string;
   /** Comment ID for mention events — used as dedup key in the queue. */
   commentId?: string;
+  /** Workspace ID for multi-workspace support. */
+  workspaceId?: string;
 };
 
 export type StateAction = "add" | "remove" | "ignore";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,9 @@ import { createEventRouter, type RouterAction } from "./event-router.js";
 import { InboxQueue, type EnqueueEntry } from "./work-queue.js";
 import { createQueueTool } from "./tools/queue-tool.js";
 import { setApiKey } from "./linear-api.js";
+import { LinearClient } from "./linear-client.js";
+import { WorkspaceRegistry, type WorkspaceConfig, type Workspace } from "./workspace-registry.js";
+import type { OpenClawPluginToolContext } from "./types.js";
 import { createIssueTool } from "./tools/linear-issue-tool.js";
 import { createCommentTool } from "./tools/linear-comment-tool.js";
 import { createTeamTool } from "./tools/linear-team-tool.js";
@@ -55,6 +58,7 @@ async function dispatchConsolidatedActions(
   actions: RouterAction[],
   api: OpenClawPluginApi,
   queue: InboxQueue,
+  sessionWorkspaceMap: Map<string, string>,
 ): Promise<void> {
   if (actions.length === 0) return;
 
@@ -80,6 +84,7 @@ async function dispatchConsolidatedActions(
     event: a.event,
     summary: a.issueLabel,
     issuePriority: a.issuePriority,
+    workspaceId: a.workspaceId,
   }));
   const added = await queue.enqueue(entries);
 
@@ -109,6 +114,11 @@ async function dispatchConsolidatedActions(
     OriginatingTo: `${CHANNEL_ID}:${first.linearUserId}`,
   });
 
+  // Track session → workspace mapping for tool resolution
+  if (first.workspaceId && route.sessionKey) {
+    sessionWorkspaceMap.set(route.sessionKey, first.workspaceId);
+  }
+
   await core.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
     ctx,
     cfg,
@@ -125,35 +135,105 @@ async function dispatchConsolidatedActions(
   });
 }
 
+function resolveWorkspace(
+  ctx: OpenClawPluginToolContext,
+  sessionWorkspaceMap: Map<string, string>,
+  registry: WorkspaceRegistry,
+): Workspace | undefined {
+  // 1. Try sessionKey lookup
+  if (ctx.sessionKey) {
+    const wsId = sessionWorkspaceMap.get(ctx.sessionKey);
+    if (wsId) {
+      const ws = registry.get(wsId);
+      if (ws) return ws;
+    }
+  }
+
+  // 2. Fallback: agentId → workspace via registry
+  if (ctx.agentId) {
+    const ws = registry.resolveByAgentId(ctx.agentId);
+    if (ws) return ws;
+  }
+
+  // 3. Final fallback: default workspace (single workspace)
+  return registry.getDefault();
+}
+
 let activeDebouncer: { flushKey: (key: string) => Promise<void> } | undefined;
 const activeDebouncerKeys = new Set<string>();
 
 export function activate(api: OpenClawPluginApi): void {
   api.logger.info("Linear plugin activated");
 
-  const linearApiKey = api.pluginConfig?.["apiKey"];
-  if (typeof linearApiKey !== "string" || !linearApiKey) {
-    api.logger.error("[linear] apiKey is not configured — plugin is inert");
-    return;
-  }
-  setApiKey(linearApiKey);
+  const registry = new WorkspaceRegistry();
+  const sessionWorkspaceMap = new Map<string, string>();
 
-  const webhookSecret = api.pluginConfig?.["webhookSecret"];
-  if (typeof webhookSecret !== "string" || !webhookSecret) {
-    api.logger.error("[linear] webhookSecret is not configured — plugin is inert");
-    return;
+  // --- Parse config: multi-workspace or single-workspace ---
+  const workspacesConfig = api.pluginConfig?.["workspaces"] as WorkspaceConfig[] | undefined;
+
+  if (workspacesConfig && Array.isArray(workspacesConfig) && workspacesConfig.length > 0) {
+    // Multi-workspace mode
+    for (const ws of workspacesConfig) {
+      if (!ws.id || !ws.apiKey || !ws.webhookSecret) {
+        api.logger.error(`[linear] Workspace missing required fields (id, apiKey, webhookSecret) — skipping`);
+        continue;
+      }
+      registry.register(ws, api.logger);
+      api.logger.info(`[linear] Registered workspace "${ws.id}"`);
+    }
+
+    if (registry.size === 0) {
+      api.logger.error("[linear] No valid workspaces configured — plugin is inert");
+      return;
+    }
+
+    // Set default client for the shim (backward compat with any code using linear-api.ts directly)
+    const defaultWs = registry.getDefault();
+    if (defaultWs) {
+      setApiKey(defaultWs.config.apiKey);
+    }
+  } else {
+    // Single-workspace mode (backward compatible)
+    const linearApiKey = api.pluginConfig?.["apiKey"];
+    if (typeof linearApiKey !== "string" || !linearApiKey) {
+      api.logger.error("[linear] apiKey is not configured — plugin is inert");
+      return;
+    }
+    setApiKey(linearApiKey);
+
+    const webhookSecret = api.pluginConfig?.["webhookSecret"];
+    if (typeof webhookSecret !== "string" || !webhookSecret) {
+      api.logger.error("[linear] webhookSecret is not configured — plugin is inert");
+      return;
+    }
+
+    const agentMapping =
+      (api.pluginConfig?.["agentMapping"] as Record<string, string>) ?? {};
+    const eventFilter =
+      (api.pluginConfig?.["eventFilter"] as string[]) ?? [];
+    const teamIds =
+      (api.pluginConfig?.["teamIds"] as string[]) ?? [];
+    const stateActions =
+      (api.pluginConfig?.["stateActions"] as Record<string, string>) ?? undefined;
+
+    registry.register(
+      {
+        id: "default",
+        apiKey: linearApiKey,
+        webhookSecret,
+        agentMapping,
+        teamIds: teamIds.length ? teamIds : undefined,
+        eventFilter: eventFilter.length ? eventFilter : undefined,
+        stateActions,
+      },
+      api.logger,
+    );
+
+    if (Object.keys(agentMapping).length === 0) {
+      api.logger.info("[linear] agentMapping is empty — all events will be dropped");
+    }
   }
 
-  const agentMapping =
-    (api.pluginConfig?.["agentMapping"] as Record<string, string>) ?? {};
-  if (Object.keys(agentMapping).length === 0) {
-    api.logger.info("[linear] agentMapping is empty — all events will be dropped");
-  }
-
-  const eventFilter =
-    (api.pluginConfig?.["eventFilter"] as string[]) ?? [];
-  const teamIds =
-    (api.pluginConfig?.["teamIds"] as string[]) ?? [];
   const rawDebounceMs = api.pluginConfig?.["debounceMs"] as number | undefined;
   const debounceMs =
     (typeof rawDebounceMs === "number" && rawDebounceMs > 0)
@@ -177,12 +257,24 @@ export function activate(api: OpenClawPluginApi): void {
     );
   });
 
+  // Register queue tool (not workspace-scoped)
   api.registerTool(createQueueTool(queue));
-  api.registerTool(createIssueTool());
-  api.registerTool(createCommentTool());
-  api.registerTool(createTeamTool());
-  api.registerTool(createProjectTool());
-  api.registerTool(createRelationTool());
+
+  // Register workspace-scoped tools via tool factory
+  api.registerTool(
+    (ctx: OpenClawPluginToolContext) => {
+      const ws = resolveWorkspace(ctx, sessionWorkspaceMap, registry);
+      if (!ws) return null;
+      return [
+        createIssueTool(ws.client),
+        createCommentTool(ws.client),
+        createTeamTool(ws.client),
+        createProjectTool(ws.client),
+        createRelationTool(ws.client),
+      ];
+    },
+    { names: ["linear_issue", "linear_comment", "linear_team", "linear_project", "linear_relation"] },
+  );
 
   // Auto-wake: after a "complete" action, dispatch a fresh session if items remain
   api.on("after_tool_call", async (event) => {
@@ -240,23 +332,12 @@ export function activate(api: OpenClawPluginApi): void {
     });
   });
 
-  const stateActions =
-    (api.pluginConfig?.["stateActions"] as Record<string, string>) ?? undefined;
-
-  const routeEvent = createEventRouter({
-    agentMapping,
-    logger: api.logger,
-    eventFilter: eventFilter.length ? eventFilter : undefined,
-    teamIds: teamIds.length ? teamIds : undefined,
-    stateActions,
-  });
-
   const debouncer = api.runtime.channel.debounce.createInboundDebouncer<RouterAction>({
     debounceMs,
     buildKey: (action) => action.agentId,
     shouldDebounce: () => true,
     onFlush: async (actions) => {
-      await dispatchConsolidatedActions(actions, api, queue);
+      await dispatchConsolidatedActions(actions, api, queue, sessionWorkspaceMap);
     },
     onError: (err) => {
       api.logger.error(
@@ -267,13 +348,23 @@ export function activate(api: OpenClawPluginApi): void {
   activeDebouncer = debouncer;
 
   const handler = createWebhookHandler({
-    webhookSecret,
+    registry,
     logger: api.logger,
-    onEvent: (event) => {
-      const actions = routeEvent(event);
+    onEvent: (event, workspace) => {
+      // Use workspace-specific router if available, otherwise fall back to first workspace
+      const ws = workspace ?? registry.getDefault();
+      if (!ws) {
+        api.logger.error("[linear] No workspace matched for event — dropping");
+        return;
+      }
+
+      const actions = ws.routeEvent(event);
       for (const action of actions) {
+        // Tag action with workspace ID
+        action.workspaceId = ws.config.id;
+
         api.logger.info(
-          `[event-router] ${action.type} agent=${action.agentId} event=${action.event}: ${action.detail}`,
+          `[event-router] ${action.type} agent=${action.agentId} event=${action.event} workspace=${ws.config.id}: ${action.detail}`,
         );
 
         if (action.type === "wake") {
@@ -290,6 +381,7 @@ export function activate(api: OpenClawPluginApi): void {
                 event: action.event,
                 summary: action.issueLabel,
                 issuePriority: action.issuePriority,
+                workspaceId: action.workspaceId,
               },
             ])
             .catch((err) =>
@@ -308,7 +400,7 @@ export function activate(api: OpenClawPluginApi): void {
   });
 
   api.logger.info(
-    `Linear webhook handler registered at /hooks/linear (debounce: ${debounceMs}ms)`,
+    `Linear webhook handler registered at /hooks/linear (debounce: ${debounceMs}ms, workspaces: ${registry.size})`,
   );
 }
 

--- a/src/linear-api.ts
+++ b/src/linear-api.ts
@@ -1,206 +1,61 @@
-const API_URL = "https://api.linear.app/graphql";
+import { LinearClient } from "./linear-client.js";
 
-let apiKey: string | undefined;
+let defaultClient: LinearClient | undefined;
 
 export function setApiKey(key: string): void {
-  apiKey = key;
+  defaultClient = new LinearClient(key);
 }
 
 /** Reset API key (for testing). */
 export function _resetApiKey(): void {
-  apiKey = undefined;
+  defaultClient = undefined;
+}
+
+function getClient(): LinearClient {
+  if (!defaultClient) {
+    throw new Error("Linear API key not set — call setApiKey() first");
+  }
+  return defaultClient;
 }
 
 export async function graphql<T>(
   query: string,
   variables?: Record<string, unknown>,
 ): Promise<T> {
-  if (!apiKey) {
-    throw new Error("Linear API key not set — call setApiKey() first");
-  }
-
-  const res = await fetch(API_URL, {
-    method: "POST",
-    headers: {
-      Authorization: apiKey,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ query, variables }),
-  });
-
-  if (!res.ok) {
-    let detail = res.statusText;
-    try {
-      const body = await res.text();
-      if (body) detail += `: ${body}`;
-    } catch {
-      // ignore read errors
-    }
-    throw new Error(`Linear API HTTP ${res.status}: ${detail}`);
-  }
-
-  const json = (await res.json()) as {
-    data?: T;
-    errors?: { message: string }[];
-  };
-
-  if (json.errors?.length) {
-    throw new Error(`Linear API error: ${json.errors[0].message}`);
-  }
-
-  return json.data as T;
+  return getClient().graphql<T>(query, variables);
 }
 
-// --- Name/ID resolution helpers ---
-
-const issueIdCache = new Map<string, string>();
-
 export async function resolveIssueId(identifier: string): Promise<string> {
-  const cached = issueIdCache.get(identifier);
-  if (cached) return cached;
-
-  const match = identifier.match(/^([A-Za-z]+)-(\d+)$/);
-  if (!match) {
-    throw new Error(`Invalid issue identifier format: ${identifier} (expected e.g. ENG-123)`);
-  }
-
-  const [, teamKey, numStr] = match;
-  const num = parseInt(numStr, 10);
-
-  const data = await graphql<{
-    issues: { nodes: { id: string }[] };
-  }>(
-    `query($teamKey: String!, $num: Float!) {
-      issues(filter: { team: { key: { eq: $teamKey } }, number: { eq: $num } }) {
-        nodes { id }
-      }
-    }`,
-    { teamKey: teamKey.toUpperCase(), num },
-  );
-
-  if (data.issues.nodes.length === 0) {
-    throw new Error(`Issue ${identifier} not found`);
-  }
-
-  const id = data.issues.nodes[0].id;
-  issueIdCache.set(identifier, id);
-  return id;
+  return getClient().resolveIssueId(identifier);
 }
 
 /** Reset issue ID cache (for testing). */
 export function _resetIssueIdCache(): void {
-  issueIdCache.clear();
+  defaultClient?._resetIssueIdCache();
 }
 
 export async function resolveTeamId(key: string): Promise<string> {
-  const data = await graphql<{
-    teams: { nodes: { id: string }[] };
-  }>(
-    `query($key: String!) {
-      teams(filter: { key: { eq: $key } }) {
-        nodes { id }
-      }
-    }`,
-    { key: key.toUpperCase() },
-  );
-
-  if (data.teams.nodes.length === 0) {
-    throw new Error(`Team with key "${key}" not found`);
-  }
-  return data.teams.nodes[0].id;
+  return getClient().resolveTeamId(key);
 }
 
 export async function resolveStateId(
   teamId: string,
   stateName: string,
 ): Promise<string> {
-  const data = await graphql<{
-    team: { states: { nodes: { id: string; name: string }[] } };
-  }>(
-    `query($teamId: String!) {
-      team(id: $teamId) {
-        states { nodes { id name } }
-      }
-    }`,
-    { teamId },
-  );
-
-  const lowerName = stateName.toLowerCase();
-  const match = data.team.states.nodes.find(
-    (s) => s.name.toLowerCase() === lowerName,
-  );
-
-  if (!match) {
-    const available = data.team.states.nodes.map((s) => s.name).join(", ");
-    throw new Error(
-      `Workflow state "${stateName}" not found. Available states: ${available}`,
-    );
-  }
-  return match.id;
+  return getClient().resolveStateId(teamId, stateName);
 }
 
 export async function resolveUserId(nameOrEmail: string): Promise<string> {
-  const data = await graphql<{
-    users: { nodes: { id: string }[] };
-  }>(
-    `query($term: String!) {
-      users(filter: { or: [{ name: { eqIgnoreCase: $term } }, { email: { eq: $term } }] }) {
-        nodes { id }
-      }
-    }`,
-    { term: nameOrEmail },
-  );
-
-  if (data.users.nodes.length === 0) {
-    throw new Error(`User "${nameOrEmail}" not found`);
-  }
-  return data.users.nodes[0].id;
+  return getClient().resolveUserId(nameOrEmail);
 }
 
 export async function resolveLabelIds(
   teamId: string,
   names: string[],
 ): Promise<string[]> {
-  const data = await graphql<{
-    team: { labels: { nodes: { id: string; name: string }[] } };
-  }>(
-    `query($teamId: String!) {
-      team(id: $teamId) {
-        labels { nodes { id name } }
-      }
-    }`,
-    { teamId },
-  );
-
-  const labelMap = new Map(
-    data.team.labels.nodes.map((l) => [l.name.toLowerCase(), l.id]),
-  );
-
-  const ids: string[] = [];
-  for (const name of names) {
-    const id = labelMap.get(name.toLowerCase());
-    if (!id) {
-      throw new Error(`Label "${name}" not found in team`);
-    }
-    ids.push(id);
-  }
-  return ids;
+  return getClient().resolveLabelIds(teamId, names);
 }
 
 export async function resolveProjectId(name: string): Promise<string> {
-  const data = await graphql<{
-    projects: { nodes: { id: string; name: string }[] };
-  }>(
-    `query($name: String!) {
-      projects(filter: { name: { eqIgnoreCase: $name } }) {
-        nodes { id name }
-      }
-    }`,
-    { name },
-  );
-
-  if (data.projects.nodes.length === 0) {
-    throw new Error(`Project "${name}" not found`);
-  }
-  return data.projects.nodes[0].id;
+  return getClient().resolveProjectId(name);
 }

--- a/src/linear-client.ts
+++ b/src/linear-client.ts
@@ -1,0 +1,196 @@
+const API_URL = "https://api.linear.app/graphql";
+
+export class LinearClient {
+  private readonly apiKey: string;
+  private readonly issueIdCache = new Map<string, string>();
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  async graphql<T>(
+    query: string,
+    variables?: Record<string, unknown>,
+  ): Promise<T> {
+    const res = await fetch(API_URL, {
+      method: "POST",
+      headers: {
+        Authorization: this.apiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+
+    if (!res.ok) {
+      let detail = res.statusText;
+      try {
+        const body = await res.text();
+        if (body) detail += `: ${body}`;
+      } catch {
+        // ignore read errors
+      }
+      throw new Error(`Linear API HTTP ${res.status}: ${detail}`);
+    }
+
+    const json = (await res.json()) as {
+      data?: T;
+      errors?: { message: string }[];
+    };
+
+    if (json.errors?.length) {
+      throw new Error(`Linear API error: ${json.errors[0].message}`);
+    }
+
+    return json.data as T;
+  }
+
+  async resolveIssueId(identifier: string): Promise<string> {
+    const cached = this.issueIdCache.get(identifier);
+    if (cached) return cached;
+
+    const match = identifier.match(/^([A-Za-z]+)-(\d+)$/);
+    if (!match) {
+      throw new Error(`Invalid issue identifier format: ${identifier} (expected e.g. ENG-123)`);
+    }
+
+    const [, teamKey, numStr] = match;
+    const num = parseInt(numStr, 10);
+
+    const data = await this.graphql<{
+      issues: { nodes: { id: string }[] };
+    }>(
+      `query($teamKey: String!, $num: Float!) {
+        issues(filter: { team: { key: { eq: $teamKey } }, number: { eq: $num } }) {
+          nodes { id }
+        }
+      }`,
+      { teamKey: teamKey.toUpperCase(), num },
+    );
+
+    if (data.issues.nodes.length === 0) {
+      throw new Error(`Issue ${identifier} not found`);
+    }
+
+    const id = data.issues.nodes[0].id;
+    this.issueIdCache.set(identifier, id);
+    return id;
+  }
+
+  /** Reset issue ID cache (for testing). */
+  _resetIssueIdCache(): void {
+    this.issueIdCache.clear();
+  }
+
+  async resolveTeamId(key: string): Promise<string> {
+    const data = await this.graphql<{
+      teams: { nodes: { id: string }[] };
+    }>(
+      `query($key: String!) {
+        teams(filter: { key: { eq: $key } }) {
+          nodes { id }
+        }
+      }`,
+      { key: key.toUpperCase() },
+    );
+
+    if (data.teams.nodes.length === 0) {
+      throw new Error(`Team with key "${key}" not found`);
+    }
+    return data.teams.nodes[0].id;
+  }
+
+  async resolveStateId(
+    teamId: string,
+    stateName: string,
+  ): Promise<string> {
+    const data = await this.graphql<{
+      team: { states: { nodes: { id: string; name: string }[] } };
+    }>(
+      `query($teamId: String!) {
+        team(id: $teamId) {
+          states { nodes { id name } }
+        }
+      }`,
+      { teamId },
+    );
+
+    const lowerName = stateName.toLowerCase();
+    const match = data.team.states.nodes.find(
+      (s) => s.name.toLowerCase() === lowerName,
+    );
+
+    if (!match) {
+      const available = data.team.states.nodes.map((s) => s.name).join(", ");
+      throw new Error(
+        `Workflow state "${stateName}" not found. Available states: ${available}`,
+      );
+    }
+    return match.id;
+  }
+
+  async resolveUserId(nameOrEmail: string): Promise<string> {
+    const data = await this.graphql<{
+      users: { nodes: { id: string }[] };
+    }>(
+      `query($term: String!) {
+        users(filter: { or: [{ name: { eqIgnoreCase: $term } }, { email: { eq: $term } }] }) {
+          nodes { id }
+        }
+      }`,
+      { term: nameOrEmail },
+    );
+
+    if (data.users.nodes.length === 0) {
+      throw new Error(`User "${nameOrEmail}" not found`);
+    }
+    return data.users.nodes[0].id;
+  }
+
+  async resolveLabelIds(
+    teamId: string,
+    names: string[],
+  ): Promise<string[]> {
+    const data = await this.graphql<{
+      team: { labels: { nodes: { id: string; name: string }[] } };
+    }>(
+      `query($teamId: String!) {
+        team(id: $teamId) {
+          labels { nodes { id name } }
+        }
+      }`,
+      { teamId },
+    );
+
+    const labelMap = new Map(
+      data.team.labels.nodes.map((l) => [l.name.toLowerCase(), l.id]),
+    );
+
+    const ids: string[] = [];
+    for (const name of names) {
+      const id = labelMap.get(name.toLowerCase());
+      if (!id) {
+        throw new Error(`Label "${name}" not found in team`);
+      }
+      ids.push(id);
+    }
+    return ids;
+  }
+
+  async resolveProjectId(name: string): Promise<string> {
+    const data = await this.graphql<{
+      projects: { nodes: { id: string; name: string }[] };
+    }>(
+      `query($name: String!) {
+        projects(filter: { name: { eqIgnoreCase: $name } }) {
+          nodes { id name }
+        }
+      }`,
+      { name },
+    );
+
+    if (data.projects.nodes.length === 0) {
+      throw new Error(`Project "${name}" not found`);
+    }
+    return data.projects.nodes[0].id;
+  }
+}

--- a/src/tools/linear-comment-tool.ts
+++ b/src/tools/linear-comment-tool.ts
@@ -1,7 +1,7 @@
 import { Type, type Static } from "@sinclair/typebox";
 import type { AnyAgentTool } from "openclaw/plugin-sdk";
 import { jsonResult, stringEnum, formatErrorMessage } from "openclaw/plugin-sdk";
-import { graphql, resolveIssueId } from "../linear-api.js";
+import type { LinearClient } from "../linear-client.js";
 
 const Params = Type.Object({
   action: stringEnum(
@@ -37,7 +37,7 @@ const Params = Type.Object({
 });
 type Params = Static<typeof Params>;
 
-export function createCommentTool(): AnyAgentTool {
+export function createCommentTool(client: LinearClient): AnyAgentTool {
   return {
     name: "linear_comment",
     label: "Linear Comment",
@@ -48,11 +48,11 @@ export function createCommentTool(): AnyAgentTool {
       try {
         switch (params.action) {
           case "list":
-            return await listComments(params);
+            return await listComments(client, params);
           case "add":
-            return await addComment(params);
+            return await addComment(client, params);
           case "update":
-            return await updateComment(params);
+            return await updateComment(client, params);
           default:
             return jsonResult({
               error: `Unknown action: ${(params as { action: string }).action}`,
@@ -67,14 +67,14 @@ export function createCommentTool(): AnyAgentTool {
   };
 }
 
-async function listComments(params: Params) {
+async function listComments(client: LinearClient, params: Params) {
   if (!params.issueId) {
     return jsonResult({ error: "issueId is required for list" });
   }
 
-  const id = await resolveIssueId(params.issueId);
+  const id = await client.resolveIssueId(params.issueId);
 
-  const data = await graphql<{
+  const data = await client.graphql<{
     issue: {
       comments: {
         nodes: {
@@ -108,7 +108,7 @@ async function listComments(params: Params) {
   return jsonResult({ comments: data.issue.comments.nodes });
 }
 
-async function addComment(params: Params) {
+async function addComment(client: LinearClient, params: Params) {
   if (!params.issueId) {
     return jsonResult({ error: "issueId is required for add" });
   }
@@ -116,7 +116,7 @@ async function addComment(params: Params) {
     return jsonResult({ error: "body is required for add" });
   }
 
-  const issueId = await resolveIssueId(params.issueId);
+  const issueId = await client.resolveIssueId(params.issueId);
 
   const input: Record<string, unknown> = {
     issueId,
@@ -126,7 +126,7 @@ async function addComment(params: Params) {
     input.parentId = params.parentCommentId;
   }
 
-  const data = await graphql<{
+  const data = await client.graphql<{
     commentCreate: {
       success: boolean;
       comment: { id: string; body: string };
@@ -144,7 +144,7 @@ async function addComment(params: Params) {
   return jsonResult(data.commentCreate);
 }
 
-async function updateComment(params: Params) {
+async function updateComment(client: LinearClient, params: Params) {
   if (!params.commentId) {
     return jsonResult({ error: "commentId is required for update" });
   }
@@ -152,7 +152,7 @@ async function updateComment(params: Params) {
     return jsonResult({ error: "body is required for update" });
   }
 
-  const data = await graphql<{
+  const data = await client.graphql<{
     commentUpdate: {
       success: boolean;
       comment: { id: string; body: string };

--- a/src/tools/linear-issue-tool.ts
+++ b/src/tools/linear-issue-tool.ts
@@ -1,15 +1,7 @@
 import { Type, type Static } from "@sinclair/typebox";
 import type { AnyAgentTool } from "openclaw/plugin-sdk";
 import { jsonResult, stringEnum, formatErrorMessage } from "openclaw/plugin-sdk";
-import {
-  graphql,
-  resolveIssueId,
-  resolveTeamId,
-  resolveStateId,
-  resolveUserId,
-  resolveLabelIds,
-  resolveProjectId,
-} from "../linear-api.js";
+import type { LinearClient } from "../linear-client.js";
 
 const Params = Type.Object({
   action: stringEnum(
@@ -86,7 +78,7 @@ const Params = Type.Object({
 });
 type Params = Static<typeof Params>;
 
-export function createIssueTool(): AnyAgentTool {
+export function createIssueTool(client: LinearClient): AnyAgentTool {
   return {
     name: "linear_issue",
     label: "Linear Issue",
@@ -97,15 +89,15 @@ export function createIssueTool(): AnyAgentTool {
       try {
         switch (params.action) {
           case "view":
-            return await viewIssue(params);
+            return await viewIssue(client, params);
           case "list":
-            return await listIssues(params);
+            return await listIssues(client, params);
           case "create":
-            return await createIssue(params);
+            return await createIssue(client, params);
           case "update":
-            return await updateIssue(params);
+            return await updateIssue(client, params);
           case "delete":
-            return await deleteIssue(params);
+            return await deleteIssue(client, params);
           default:
             return jsonResult({
               error: `Unknown action: ${(params as { action: string }).action}`,
@@ -120,14 +112,14 @@ export function createIssueTool(): AnyAgentTool {
   };
 }
 
-async function viewIssue(params: Params) {
+async function viewIssue(client: LinearClient, params: Params) {
   if (!params.issueId) {
     return jsonResult({ error: "issueId is required for view" });
   }
 
-  const id = await resolveIssueId(params.issueId);
+  const id = await client.resolveIssueId(params.issueId);
 
-  const data = await graphql<{ issue: Record<string, unknown> }>(
+  const data = await client.graphql<{ issue: Record<string, unknown> }>(
     `query($id: String!) {
       issue(id: $id) {
         id
@@ -156,7 +148,7 @@ async function viewIssue(params: Params) {
   return jsonResult(data.issue);
 }
 
-async function listIssues(params: Params) {
+async function listIssues(client: LinearClient, params: Params) {
   const filterParts: string[] = [];
   const variables: Record<string, unknown> = {};
 
@@ -193,7 +185,7 @@ async function listIssues(params: Params) {
   if (params.team) varDecls.push("$team: String!");
   if (params.project) varDecls.push("$project: String!");
 
-  const data = await graphql<{
+  const data = await client.graphql<{
     issues: {
       nodes: Record<string, unknown>[];
     };
@@ -222,7 +214,7 @@ async function listIssues(params: Params) {
   return jsonResult({ issues: data.issues.nodes });
 }
 
-async function createIssue(params: Params) {
+async function createIssue(client: LinearClient, params: Params) {
   if (!params.title) {
     return jsonResult({ error: "title is required for create" });
   }
@@ -230,10 +222,10 @@ async function createIssue(params: Params) {
   const input: Record<string, unknown> = { title: params.title };
 
   if (params.team) {
-    input.teamId = await resolveTeamId(params.team);
+    input.teamId = await client.resolveTeamId(params.team);
   } else {
     // Need a team — fetch the first one
-    const teams = await graphql<{
+    const teams = await client.graphql<{
       teams: { nodes: { id: string }[] };
     }>(`{ teams(first: 1) { nodes { id } } }`);
     if (teams.teams.nodes.length === 0) {
@@ -246,26 +238,26 @@ async function createIssue(params: Params) {
   if (params.priority !== undefined) input.priority = params.priority;
 
   if (params.state) {
-    input.stateId = await resolveStateId(input.teamId as string, params.state);
+    input.stateId = await client.resolveStateId(input.teamId as string, params.state);
   }
   if (params.assignee) {
-    input.assigneeId = await resolveUserId(params.assignee);
+    input.assigneeId = await client.resolveUserId(params.assignee);
   }
   if (params.project) {
-    input.projectId = await resolveProjectId(params.project);
+    input.projectId = await client.resolveProjectId(params.project);
   }
   if (params.parent) {
-    input.parentId = await resolveIssueId(params.parent);
+    input.parentId = await client.resolveIssueId(params.parent);
   }
   if (params.labels?.length) {
-    input.labelIds = await resolveLabelIds(
+    input.labelIds = await client.resolveLabelIds(
       input.teamId as string,
       params.labels,
     );
   }
   if (params.dueDate !== undefined) input.dueDate = params.dueDate || null;
 
-  const data = await graphql<{
+  const data = await client.graphql<{
     issueCreate: {
       success: boolean;
       issue: { id: string; identifier: string; url: string; title: string };
@@ -283,18 +275,18 @@ async function createIssue(params: Params) {
   return jsonResult(data.issueCreate);
 }
 
-async function updateIssue(params: Params) {
+async function updateIssue(client: LinearClient, params: Params) {
   if (!params.issueId) {
     return jsonResult({ error: "issueId is required for update" });
   }
 
-  const id = await resolveIssueId(params.issueId);
+  const id = await client.resolveIssueId(params.issueId);
   const input: Record<string, unknown> = {};
 
   // We need the team ID for state/label resolution, or the current description for append
   let teamId: string | undefined;
   if (params.state || params.labels?.length || params.appendDescription) {
-    const issueData = await graphql<{
+    const issueData = await client.graphql<{
       issue: { team: { id: string }; description?: string };
     }>(
       `query($id: String!) { issue(id: $id) { team { id } description } }`,
@@ -311,15 +303,15 @@ async function updateIssue(params: Params) {
   if (params.title) input.title = params.title;
   if (params.description !== undefined && !params.appendDescription) input.description = params.description;
   if (params.priority !== undefined) input.priority = params.priority;
-  if (params.state) input.stateId = await resolveStateId(teamId!, params.state);
-  if (params.assignee) input.assigneeId = await resolveUserId(params.assignee);
-  if (params.project) input.projectId = await resolveProjectId(params.project);
+  if (params.state) input.stateId = await client.resolveStateId(teamId!, params.state);
+  if (params.assignee) input.assigneeId = await client.resolveUserId(params.assignee);
+  if (params.project) input.projectId = await client.resolveProjectId(params.project);
   if (params.labels?.length) {
-    input.labelIds = await resolveLabelIds(teamId!, params.labels);
+    input.labelIds = await client.resolveLabelIds(teamId!, params.labels);
   }
   if (params.dueDate !== undefined) input.dueDate = params.dueDate || null;
 
-  const data = await graphql<{
+  const data = await client.graphql<{
     issueUpdate: {
       success: boolean;
       issue: { id: string; identifier: string; title: string };
@@ -337,14 +329,14 @@ async function updateIssue(params: Params) {
   return jsonResult(data.issueUpdate);
 }
 
-async function deleteIssue(params: Params) {
+async function deleteIssue(client: LinearClient, params: Params) {
   if (!params.issueId) {
     return jsonResult({ error: "issueId is required for delete" });
   }
 
-  const id = await resolveIssueId(params.issueId);
+  const id = await client.resolveIssueId(params.issueId);
 
-  const data = await graphql<{
+  const data = await client.graphql<{
     issueDelete: { success: boolean };
   }>(
     `mutation($id: String!) {

--- a/src/tools/linear-project-tool.ts
+++ b/src/tools/linear-project-tool.ts
@@ -1,7 +1,7 @@
 import { Type, type Static } from "@sinclair/typebox";
 import type { AnyAgentTool } from "openclaw/plugin-sdk";
 import { jsonResult, stringEnum, formatErrorMessage } from "openclaw/plugin-sdk";
-import { graphql, resolveTeamId } from "../linear-api.js";
+import type { LinearClient } from "../linear-client.js";
 
 const Params = Type.Object({
   action: stringEnum(
@@ -42,7 +42,7 @@ const Params = Type.Object({
 });
 type Params = Static<typeof Params>;
 
-export function createProjectTool(): AnyAgentTool {
+export function createProjectTool(client: LinearClient): AnyAgentTool {
   return {
     name: "linear_project",
     label: "Linear Project",
@@ -53,11 +53,11 @@ export function createProjectTool(): AnyAgentTool {
       try {
         switch (params.action) {
           case "list":
-            return await listProjects(params);
+            return await listProjects(client, params);
           case "view":
-            return await viewProject(params);
+            return await viewProject(client, params);
           case "create":
-            return await createProject(params);
+            return await createProject(client, params);
           default:
             return jsonResult({
               error: `Unknown action: ${(params as { action: string }).action}`,
@@ -72,7 +72,7 @@ export function createProjectTool(): AnyAgentTool {
   };
 }
 
-async function listProjects(params: Params) {
+async function listProjects(client: LinearClient, params: Params) {
   const filterParts: string[] = [];
   const variables: Record<string, unknown> = {};
   const varDecls: string[] = [];
@@ -97,7 +97,7 @@ async function listProjects(params: Params) {
     : "";
   const varStr = varDecls.length ? `(${varDecls.join(", ")})` : "";
 
-  const data = await graphql<{
+  const data = await client.graphql<{
     projects: {
       nodes: {
         id: string;
@@ -123,12 +123,12 @@ async function listProjects(params: Params) {
   return jsonResult({ projects: data.projects.nodes });
 }
 
-async function viewProject(params: Params) {
+async function viewProject(client: LinearClient, params: Params) {
   if (!params.projectId) {
     return jsonResult({ error: "projectId is required for view" });
   }
 
-  const data = await graphql<{
+  const data = await client.graphql<{
     project: Record<string, unknown>;
   }>(
     `query($id: String!) {
@@ -150,7 +150,7 @@ async function viewProject(params: Params) {
   return jsonResult(data.project);
 }
 
-async function createProject(params: Params) {
+async function createProject(client: LinearClient, params: Params) {
   if (!params.name) {
     return jsonResult({ error: "name is required for create" });
   }
@@ -159,11 +159,11 @@ async function createProject(params: Params) {
 
   if (params.description) input.description = params.description;
   if (params.team) {
-    const teamId = await resolveTeamId(params.team);
+    const teamId = await client.resolveTeamId(params.team);
     input.teamIds = [teamId];
   }
 
-  const data = await graphql<{
+  const data = await client.graphql<{
     projectCreate: {
       success: boolean;
       project: { id: string; name: string; url: string };

--- a/src/tools/linear-relation-tool.ts
+++ b/src/tools/linear-relation-tool.ts
@@ -1,7 +1,7 @@
 import { Type, type Static } from "@sinclair/typebox";
 import type { AnyAgentTool } from "openclaw/plugin-sdk";
 import { jsonResult, stringEnum, optionalStringEnum, formatErrorMessage } from "openclaw/plugin-sdk";
-import { graphql, resolveIssueId } from "../linear-api.js";
+import type { LinearClient } from "../linear-client.js";
 
 const RELATION_TYPE_MAP: Record<string, string> = {
   blocks: "blocks",
@@ -46,7 +46,7 @@ const Params = Type.Object({
 });
 type Params = Static<typeof Params>;
 
-export function createRelationTool(): AnyAgentTool {
+export function createRelationTool(client: LinearClient): AnyAgentTool {
   return {
     name: "linear_relation",
     label: "Linear Relation",
@@ -57,11 +57,11 @@ export function createRelationTool(): AnyAgentTool {
       try {
         switch (params.action) {
           case "list":
-            return await listRelations(params);
+            return await listRelations(client, params);
           case "add":
-            return await addRelation(params);
+            return await addRelation(client, params);
           case "delete":
-            return await deleteRelation(params);
+            return await deleteRelation(client, params);
           default:
             return jsonResult({
               error: `Unknown action: ${(params as { action: string }).action}`,
@@ -76,14 +76,14 @@ export function createRelationTool(): AnyAgentTool {
   };
 }
 
-async function listRelations(params: Params) {
+async function listRelations(client: LinearClient, params: Params) {
   if (!params.issueId) {
     return jsonResult({ error: "issueId is required for list" });
   }
 
-  const id = await resolveIssueId(params.issueId);
+  const id = await client.resolveIssueId(params.issueId);
 
-  const data = await graphql<{
+  const data = await client.graphql<{
     issue: {
       relations: {
         nodes: {
@@ -140,7 +140,7 @@ async function listRelations(params: Params) {
   });
 }
 
-async function addRelation(params: Params) {
+async function addRelation(client: LinearClient, params: Params) {
   if (!params.issueId) {
     return jsonResult({ error: "issueId is required for add" });
   }
@@ -161,14 +161,14 @@ async function addRelation(params: Params) {
   let relatedIssueId: string;
 
   if (params.type === "blocked-by") {
-    issueId = await resolveIssueId(params.relatedIssueId);
-    relatedIssueId = await resolveIssueId(params.issueId);
+    issueId = await client.resolveIssueId(params.relatedIssueId);
+    relatedIssueId = await client.resolveIssueId(params.issueId);
   } else {
-    issueId = await resolveIssueId(params.issueId);
-    relatedIssueId = await resolveIssueId(params.relatedIssueId);
+    issueId = await client.resolveIssueId(params.issueId);
+    relatedIssueId = await client.resolveIssueId(params.relatedIssueId);
   }
 
-  const data = await graphql<{
+  const data = await client.graphql<{
     issueRelationCreate: {
       success: boolean;
       issueRelation: { id: string; type: string };
@@ -192,12 +192,12 @@ async function addRelation(params: Params) {
   return jsonResult(data.issueRelationCreate);
 }
 
-async function deleteRelation(params: Params) {
+async function deleteRelation(client: LinearClient, params: Params) {
   if (!params.relationId) {
     return jsonResult({ error: "relationId is required for delete" });
   }
 
-  const data = await graphql<{
+  const data = await client.graphql<{
     issueRelationDelete: { success: boolean };
   }>(
     `mutation($id: String!) {

--- a/src/tools/linear-team-tool.ts
+++ b/src/tools/linear-team-tool.ts
@@ -1,7 +1,7 @@
 import { Type, type Static } from "@sinclair/typebox";
 import type { AnyAgentTool } from "openclaw/plugin-sdk";
 import { jsonResult, stringEnum, formatErrorMessage } from "openclaw/plugin-sdk";
-import { graphql } from "../linear-api.js";
+import type { LinearClient } from "../linear-client.js";
 
 const Params = Type.Object({
   action: stringEnum(
@@ -20,7 +20,7 @@ const Params = Type.Object({
 });
 type Params = Static<typeof Params>;
 
-export function createTeamTool(): AnyAgentTool {
+export function createTeamTool(client: LinearClient): AnyAgentTool {
   return {
     name: "linear_team",
     label: "Linear Team",
@@ -30,9 +30,9 @@ export function createTeamTool(): AnyAgentTool {
       try {
         switch (params.action) {
           case "list":
-            return await listTeams();
+            return await listTeams(client);
           case "members":
-            return await listMembers(params);
+            return await listMembers(client, params);
           default:
             return jsonResult({
               error: `Unknown action: ${(params as { action: string }).action}`,
@@ -47,8 +47,8 @@ export function createTeamTool(): AnyAgentTool {
   };
 }
 
-async function listTeams() {
-  const data = await graphql<{
+async function listTeams(client: LinearClient) {
+  const data = await client.graphql<{
     teams: {
       nodes: { id: string; name: string; key: string }[];
     };
@@ -57,12 +57,12 @@ async function listTeams() {
   return jsonResult({ teams: data.teams.nodes });
 }
 
-async function listMembers(params: Params) {
+async function listMembers(client: LinearClient, params: Params) {
   if (!params.team) {
     return jsonResult({ error: "team is required for members" });
   }
 
-  const data = await graphql<{
+  const data = await client.graphql<{
     teams: {
       nodes: {
         members: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,14 @@
+/**
+ * Context passed to tool factories by the plugin SDK.
+ * Re-declared here to avoid importing from internal SDK paths.
+ */
+export type OpenClawPluginToolContext = {
+  config?: unknown;
+  workspaceDir?: string;
+  agentDir?: string;
+  agentId?: string;
+  sessionKey?: string;
+  messageChannel?: string;
+  agentAccountId?: string;
+  sandboxed?: boolean;
+};

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -1,6 +1,7 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { formatErrorMessage } from "openclaw/plugin-sdk";
+import type { WorkspaceRegistry, Workspace } from "./workspace-registry.js";
 
 export type LinearWebhookPayload = {
   action: string;
@@ -10,14 +11,29 @@ export type LinearWebhookPayload = {
   createdAt: string;
 };
 
-type WebhookHandlerDeps = {
+/** Single-secret mode (backward compatible). */
+type SingleSecretDeps = {
   webhookSecret: string;
+  registry?: undefined;
   logger: {
     info: (message: string) => void;
     error: (message: string) => void;
   };
-  onEvent?: (event: LinearWebhookPayload) => void;
+  onEvent?: (event: LinearWebhookPayload, workspace?: Workspace) => void;
 };
+
+/** Multi-workspace mode. */
+type RegistryDeps = {
+  webhookSecret?: undefined;
+  registry: WorkspaceRegistry;
+  logger: {
+    info: (message: string) => void;
+    error: (message: string) => void;
+  };
+  onEvent?: (event: LinearWebhookPayload, workspace?: Workspace) => void;
+};
+
+type WebhookHandlerDeps = SingleSecretDeps | RegistryDeps;
 
 const MAX_BODY_BYTES = 1024 * 1024; // 1 MB
 const DEDUP_TTL_MS = 10 * 60 * 1000; // 10 minutes
@@ -93,10 +109,29 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
     }
 
     const signature = req.headers["linear-signature"];
-    if (typeof signature !== "string" || !verifySignature(rawBody, signature, deps.webhookSecret)) {
+    if (typeof signature !== "string") {
       res.writeHead(400);
       res.end("Invalid signature");
       return;
+    }
+
+    // Verify signature: registry mode tries all workspaces, single-secret mode uses one secret
+    let matchedWorkspace: Workspace | undefined;
+
+    if (deps.registry) {
+      const ws = deps.registry.matchBySignature(rawBody, signature);
+      if (!ws) {
+        res.writeHead(400);
+        res.end("Invalid signature");
+        return;
+      }
+      matchedWorkspace = ws;
+    } else {
+      if (!verifySignature(rawBody, signature, deps.webhookSecret)) {
+        res.writeHead(400);
+        res.end("Invalid signature");
+        return;
+      }
     }
 
     let event: LinearWebhookPayload;
@@ -139,7 +174,7 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
     res.end("OK");
 
     try {
-      deps.onEvent?.(event);
+      deps.onEvent?.(event, matchedWorkspace);
     } catch (err) {
       deps.logger.error(`Event handler error: ${formatErrorMessage(err)}`);
     }

--- a/src/work-queue.ts
+++ b/src/work-queue.ts
@@ -21,6 +21,8 @@ export interface QueueItem {
   priority: number;
   addedAt: string;
   status: "pending" | "in_progress";
+  /** Workspace ID for multi-workspace dedup isolation. */
+  workspaceId?: string;
 }
 
 export const QUEUE_EVENT: Record<string, string> = {
@@ -43,6 +45,8 @@ export interface EnqueueEntry {
   event: string;
   summary: string;
   issuePriority: number;
+  /** Workspace ID for multi-workspace dedup isolation. */
+  workspaceId?: string;
 }
 
 /** Map Linear priority (0=none) so no-priority sorts last. */
@@ -173,9 +177,9 @@ export class InboxQueue {
         writeJsonl(this.path, filtered);
       }
 
-      // Build dedup set from remaining items using id + mapped queue event
+      // Build dedup set from remaining items using workspaceId + id + mapped queue event
       const existingKeys = new Set(
-        filtered.map((item) => `${item.id}:${item.event}`),
+        filtered.map((item) => `${item.workspaceId ?? "default"}:${item.id}:${item.event}`),
       );
 
       const newItems: QueueItem[] = [];
@@ -185,10 +189,11 @@ export class InboxQueue {
         const queueEvent = QUEUE_EVENT[entry.event];
         if (!queueEvent) continue; // skip unmapped events
 
-        const dedupKey = `${entry.id}:${queueEvent}`;
+        const wsId = entry.workspaceId ?? "default";
+        const dedupKey = `${wsId}:${entry.id}:${queueEvent}`;
         if (existingKeys.has(dedupKey)) continue;
 
-        newItems.push({
+        const item: QueueItem = {
           id: entry.id,
           issueId: entry.issueId ?? entry.id,
           event: queueEvent,
@@ -196,7 +201,10 @@ export class InboxQueue {
           priority: queueEvent === "mention" ? 0 : mapPriority(entry.issuePriority),
           addedAt: now,
           status: "pending",
-        });
+        };
+        if (entry.workspaceId) item.workspaceId = entry.workspaceId;
+
+        newItems.push(item);
         existingKeys.add(dedupKey);
       }
 

--- a/src/workspace-registry.ts
+++ b/src/workspace-registry.ts
@@ -1,0 +1,88 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { LinearClient } from "./linear-client.js";
+import { createEventRouter } from "./event-router.js";
+
+export interface WorkspaceConfig {
+  id: string;
+  apiKey: string;
+  webhookSecret: string;
+  agentMapping: Record<string, string>;
+  teamIds?: string[];
+  eventFilter?: string[];
+  stateActions?: Record<string, string>;
+}
+
+export interface Workspace {
+  config: WorkspaceConfig;
+  client: LinearClient;
+  routeEvent: ReturnType<typeof createEventRouter>;
+}
+
+function verifySignature(body: string, signature: string, secret: string): boolean {
+  const expected = createHmac("sha256", secret).update(body).digest("hex");
+  if (expected.length !== signature.length) {
+    return false;
+  }
+  return timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+}
+
+export class WorkspaceRegistry {
+  private readonly workspaces = new Map<string, Workspace>();
+  private readonly agentIdIndex = new Map<string, Workspace>();
+
+  register(
+    config: WorkspaceConfig,
+    logger: { info: (message: string) => void; error: (message: string) => void },
+  ): void {
+    const client = new LinearClient(config.apiKey);
+
+    const routeEvent = createEventRouter({
+      agentMapping: config.agentMapping,
+      logger,
+      eventFilter: config.eventFilter?.length ? config.eventFilter : undefined,
+      teamIds: config.teamIds?.length ? config.teamIds : undefined,
+      stateActions: config.stateActions,
+    });
+
+    const workspace: Workspace = { config, client, routeEvent };
+    this.workspaces.set(config.id, workspace);
+
+    // Build reverse index: agentId → workspace
+    for (const agentId of Object.values(config.agentMapping)) {
+      this.agentIdIndex.set(agentId, workspace);
+    }
+  }
+
+  /** Try each workspace's secret until one matches. Returns null if none match. */
+  matchBySignature(rawBody: string, signature: string): Workspace | null {
+    for (const workspace of this.workspaces.values()) {
+      if (verifySignature(rawBody, signature, workspace.config.webhookSecret)) {
+        return workspace;
+      }
+    }
+    return null;
+  }
+
+  get(id: string): Workspace | undefined {
+    return this.workspaces.get(id);
+  }
+
+  getDefault(): Workspace | undefined {
+    const iter = this.workspaces.values();
+    const first = iter.next();
+    return first.done ? undefined : first.value;
+  }
+
+  all(): Workspace[] {
+    return [...this.workspaces.values()];
+  }
+
+  /** Reverse lookup: agentId → workspace (built from agentMappings). */
+  resolveByAgentId(agentId: string): Workspace | undefined {
+    return this.agentIdIndex.get(agentId);
+  }
+
+  get size(): number {
+    return this.workspaces.size;
+  }
+}

--- a/test/linear-client.test.ts
+++ b/test/linear-client.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { LinearClient } from "../src/linear-client.js";
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockGraphqlResponse(data: unknown) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ data }),
+  });
+}
+
+function mockGraphqlError(message: string) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ errors: [{ message }] }),
+  });
+}
+
+describe("LinearClient", () => {
+  describe("graphql", () => {
+    it("sends correct headers and body", async () => {
+      const client = new LinearClient("lin_api_test123");
+      mockGraphqlResponse({ viewer: { id: "u1" } });
+
+      await client.graphql("{ viewer { id } }");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://api.linear.app/graphql",
+        expect.objectContaining({
+          method: "POST",
+          headers: {
+            Authorization: "lin_api_test123",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ query: "{ viewer { id } }" }),
+        }),
+      );
+    });
+
+    it("returns data on success", async () => {
+      const client = new LinearClient("lin_api_test");
+      mockGraphqlResponse({ viewer: { id: "u1", name: "Test" } });
+
+      const result = await client.graphql<{ viewer: { id: string; name: string } }>(
+        "{ viewer { id name } }",
+      );
+      expect(result.viewer).toEqual({ id: "u1", name: "Test" });
+    });
+
+    it("passes variables", async () => {
+      const client = new LinearClient("lin_api_test");
+      mockGraphqlResponse({ issue: { id: "i1" } });
+
+      await client.graphql("query($id: String!) { issue(id: $id) { id } }", {
+        id: "i1",
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.variables).toEqual({ id: "i1" });
+    });
+
+    it("throws on HTTP error", async () => {
+      const client = new LinearClient("lin_api_test");
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        text: async () => '{"error":"Invalid API key"}',
+      });
+
+      await expect(client.graphql("{ viewer { id } }")).rejects.toThrow(
+        'HTTP 401: Unauthorized: {"error":"Invalid API key"}',
+      );
+    });
+
+    it("throws on GraphQL error", async () => {
+      const client = new LinearClient("lin_api_test");
+      mockGraphqlError("Entity not found");
+
+      await expect(client.graphql("{ issue(id: \"bad\") { id } }")).rejects.toThrow(
+        "Entity not found",
+      );
+    });
+  });
+
+  describe("resolveIssueId", () => {
+    it("resolves a valid identifier", async () => {
+      const client = new LinearClient("lin_api_test");
+      mockGraphqlResponse({
+        issues: { nodes: [{ id: "uuid-123" }] },
+      });
+
+      const id = await client.resolveIssueId("ENG-42");
+      expect(id).toBe("uuid-123");
+    });
+
+    it("caches resolved IDs", async () => {
+      const client = new LinearClient("lin_api_test");
+      mockGraphqlResponse({
+        issues: { nodes: [{ id: "uuid-123" }] },
+      });
+
+      await client.resolveIssueId("ENG-42");
+      const id2 = await client.resolveIssueId("ENG-42");
+      expect(id2).toBe("uuid-123");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("has independent cache per instance", async () => {
+      const client1 = new LinearClient("key1");
+      const client2 = new LinearClient("key2");
+
+      mockGraphqlResponse({ issues: { nodes: [{ id: "uuid-1" }] } });
+      mockGraphqlResponse({ issues: { nodes: [{ id: "uuid-2" }] } });
+
+      await client1.resolveIssueId("ENG-42");
+      await client2.resolveIssueId("ENG-42");
+
+      expect(mockFetch).toHaveBeenCalledTimes(2); // Not shared
+    });
+
+    it("throws on invalid format", async () => {
+      const client = new LinearClient("lin_api_test");
+      await expect(client.resolveIssueId("bad-format-123")).rejects.toThrow(
+        "Invalid issue identifier format",
+      );
+    });
+
+    it("throws when issue not found", async () => {
+      const client = new LinearClient("lin_api_test");
+      mockGraphqlResponse({ issues: { nodes: [] } });
+      await expect(client.resolveIssueId("ENG-999")).rejects.toThrow(
+        "Issue ENG-999 not found",
+      );
+    });
+  });
+
+  describe("resolveTeamId", () => {
+    it("resolves team by key", async () => {
+      const client = new LinearClient("lin_api_test");
+      mockGraphqlResponse({ teams: { nodes: [{ id: "team-1" }] } });
+      const id = await client.resolveTeamId("ENG");
+      expect(id).toBe("team-1");
+    });
+
+    it("throws when team not found", async () => {
+      const client = new LinearClient("lin_api_test");
+      mockGraphqlResponse({ teams: { nodes: [] } });
+      await expect(client.resolveTeamId("NOPE")).rejects.toThrow('Team with key "NOPE" not found');
+    });
+  });
+
+  describe("resolveStateId", () => {
+    it("resolves state by name and team", async () => {
+      const client = new LinearClient("lin_api_test");
+      mockGraphqlResponse({
+        team: {
+          states: {
+            nodes: [
+              { id: "state-1", name: "In Progress" },
+              { id: "state-2", name: "Done" },
+            ],
+          },
+        },
+      });
+      const id = await client.resolveStateId("team-1", "In Progress");
+      expect(id).toBe("state-1");
+    });
+
+    it("is case-insensitive", async () => {
+      const client = new LinearClient("lin_api_test");
+      mockGraphqlResponse({
+        team: {
+          states: { nodes: [{ id: "state-1", name: "In Progress" }] },
+        },
+      });
+      const id = await client.resolveStateId("team-1", "in progress");
+      expect(id).toBe("state-1");
+    });
+
+    it("throws when state not found", async () => {
+      const client = new LinearClient("lin_api_test");
+      mockGraphqlResponse({
+        team: {
+          states: {
+            nodes: [
+              { id: "state-1", name: "Todo" },
+              { id: "state-2", name: "Done" },
+            ],
+          },
+        },
+      });
+      await expect(client.resolveStateId("team-1", "Nonexistent")).rejects.toThrow(
+        'Workflow state "Nonexistent" not found. Available states: Todo, Done',
+      );
+    });
+  });
+
+  describe("resolveUserId", () => {
+    it("resolves user by name or email", async () => {
+      const client = new LinearClient("lin_api_test");
+      mockGraphqlResponse({ users: { nodes: [{ id: "user-1" }] } });
+      const id = await client.resolveUserId("Alice");
+      expect(id).toBe("user-1");
+    });
+
+    it("throws when user not found", async () => {
+      const client = new LinearClient("lin_api_test");
+      mockGraphqlResponse({ users: { nodes: [] } });
+      await expect(client.resolveUserId("nobody")).rejects.toThrow('User "nobody" not found');
+    });
+  });
+
+  describe("resolveLabelIds", () => {
+    it("resolves label names to IDs", async () => {
+      const client = new LinearClient("lin_api_test");
+      mockGraphqlResponse({
+        team: {
+          labels: {
+            nodes: [
+              { id: "l1", name: "Bug" },
+              { id: "l2", name: "Feature" },
+            ],
+          },
+        },
+      });
+      const ids = await client.resolveLabelIds("team-1", ["Bug", "Feature"]);
+      expect(ids).toEqual(["l1", "l2"]);
+    });
+
+    it("throws when label not found", async () => {
+      const client = new LinearClient("lin_api_test");
+      mockGraphqlResponse({
+        team: { labels: { nodes: [{ id: "l1", name: "Bug" }] } },
+      });
+      await expect(client.resolveLabelIds("team-1", ["Missing"])).rejects.toThrow(
+        'Label "Missing" not found in team',
+      );
+    });
+  });
+
+  describe("resolveProjectId", () => {
+    it("resolves project by name", async () => {
+      const client = new LinearClient("lin_api_test");
+      mockGraphqlResponse({
+        projects: { nodes: [{ id: "proj-1", name: "Alpha" }] },
+      });
+      const id = await client.resolveProjectId("Alpha");
+      expect(id).toBe("proj-1");
+    });
+
+    it("throws when project not found", async () => {
+      const client = new LinearClient("lin_api_test");
+      mockGraphqlResponse({ projects: { nodes: [] } });
+      await expect(client.resolveProjectId("Nonexistent")).rejects.toThrow(
+        'Project "Nonexistent" not found',
+      );
+    });
+  });
+});

--- a/test/tools/linear-comment-tool.test.ts
+++ b/test/tools/linear-comment-tool.test.ts
@@ -1,35 +1,41 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { LinearClient } from "../../src/linear-client.js";
+import { createCommentTool } from "../../src/tools/linear-comment-tool.js";
 
-vi.mock("../../src/linear-api.js", () => ({
-  graphql: vi.fn(),
-  resolveIssueId: vi.fn(),
-}));
-
-const { graphql, resolveIssueId } = await import("../../src/linear-api.js");
-const { createCommentTool } = await import("../../src/tools/linear-comment-tool.js");
-
-const mockedGraphql = vi.mocked(graphql);
-const mockedResolveIssueId = vi.mocked(resolveIssueId);
+function mockClient(): LinearClient {
+  return {
+    graphql: vi.fn(),
+    resolveIssueId: vi.fn(),
+    resolveTeamId: vi.fn(),
+    resolveStateId: vi.fn(),
+    resolveUserId: vi.fn(),
+    resolveLabelIds: vi.fn(),
+    resolveProjectId: vi.fn(),
+    _resetIssueIdCache: vi.fn(),
+  } as unknown as LinearClient;
+}
 
 function parse(result: { content: { type: string; text?: string }[] }) {
   const text = result.content.find((c) => c.type === "text")?.text;
   return text ? JSON.parse(text) : undefined;
 }
 
-beforeEach(() => {
-  vi.clearAllMocks();
-});
-
 describe("linear_comment tool", () => {
+  let client: ReturnType<typeof mockClient>;
+
+  beforeEach(() => {
+    client = mockClient();
+  });
+
   it("has correct name", () => {
-    const tool = createCommentTool();
+    const tool = createCommentTool(client);
     expect(tool.name).toBe("linear_comment");
   });
 
   describe("list", () => {
     it("returns comments for an issue", async () => {
-      mockedResolveIssueId.mockResolvedValue("uuid-1");
-      mockedGraphql.mockResolvedValue({
+      vi.mocked(client.resolveIssueId).mockResolvedValue("uuid-1");
+      vi.mocked(client.graphql).mockResolvedValue({
         issue: {
           comments: {
             nodes: [
@@ -46,7 +52,7 @@ describe("linear_comment tool", () => {
         },
       });
 
-      const tool = createCommentTool();
+      const tool = createCommentTool(client);
       const result = await tool.execute("call-1", {
         action: "list",
         issueId: "ENG-42",
@@ -57,7 +63,7 @@ describe("linear_comment tool", () => {
     });
 
     it("returns error without issueId", async () => {
-      const tool = createCommentTool();
+      const tool = createCommentTool(client);
       const result = await tool.execute("call-1", { action: "list" });
       const data = parse(result);
       expect(data.error).toContain("issueId is required");
@@ -66,15 +72,15 @@ describe("linear_comment tool", () => {
 
   describe("add", () => {
     it("creates a comment", async () => {
-      mockedResolveIssueId.mockResolvedValue("uuid-1");
-      mockedGraphql.mockResolvedValue({
+      vi.mocked(client.resolveIssueId).mockResolvedValue("uuid-1");
+      vi.mocked(client.graphql).mockResolvedValue({
         commentCreate: {
           success: true,
           comment: { id: "c-new", body: "My comment" },
         },
       });
 
-      const tool = createCommentTool();
+      const tool = createCommentTool(client);
       const result = await tool.execute("call-1", {
         action: "add",
         issueId: "ENG-42",
@@ -85,15 +91,15 @@ describe("linear_comment tool", () => {
     });
 
     it("supports threading with parentCommentId", async () => {
-      mockedResolveIssueId.mockResolvedValue("uuid-1");
-      mockedGraphql.mockResolvedValue({
+      vi.mocked(client.resolveIssueId).mockResolvedValue("uuid-1");
+      vi.mocked(client.graphql).mockResolvedValue({
         commentCreate: {
           success: true,
           comment: { id: "c-reply", body: "Reply" },
         },
       });
 
-      const tool = createCommentTool();
+      const tool = createCommentTool(client);
       await tool.execute("call-1", {
         action: "add",
         issueId: "ENG-42",
@@ -101,13 +107,13 @@ describe("linear_comment tool", () => {
         parentCommentId: "c1",
       });
 
-      const call = mockedGraphql.mock.calls[0];
+      const call = vi.mocked(client.graphql).mock.calls[0];
       const vars = call[1] as { input: { parentId?: string } };
       expect(vars.input.parentId).toBe("c1");
     });
 
     it("returns error without issueId", async () => {
-      const tool = createCommentTool();
+      const tool = createCommentTool(client);
       const result = await tool.execute("call-1", {
         action: "add",
         body: "text",
@@ -117,7 +123,7 @@ describe("linear_comment tool", () => {
     });
 
     it("returns error without body", async () => {
-      const tool = createCommentTool();
+      const tool = createCommentTool(client);
       const result = await tool.execute("call-1", {
         action: "add",
         issueId: "ENG-42",
@@ -129,14 +135,14 @@ describe("linear_comment tool", () => {
 
   describe("update", () => {
     it("updates a comment", async () => {
-      mockedGraphql.mockResolvedValue({
+      vi.mocked(client.graphql).mockResolvedValue({
         commentUpdate: {
           success: true,
           comment: { id: "c1", body: "Updated" },
         },
       });
 
-      const tool = createCommentTool();
+      const tool = createCommentTool(client);
       const result = await tool.execute("call-1", {
         action: "update",
         commentId: "c1",
@@ -147,7 +153,7 @@ describe("linear_comment tool", () => {
     });
 
     it("returns error without commentId", async () => {
-      const tool = createCommentTool();
+      const tool = createCommentTool(client);
       const result = await tool.execute("call-1", {
         action: "update",
         body: "text",
@@ -157,7 +163,7 @@ describe("linear_comment tool", () => {
     });
 
     it("returns error without body", async () => {
-      const tool = createCommentTool();
+      const tool = createCommentTool(client);
       const result = await tool.execute("call-1", {
         action: "update",
         commentId: "c1",
@@ -168,9 +174,9 @@ describe("linear_comment tool", () => {
   });
 
   it("catches and returns API errors", async () => {
-    mockedResolveIssueId.mockRejectedValue(new Error("API down"));
+    vi.mocked(client.resolveIssueId).mockRejectedValue(new Error("API down"));
 
-    const tool = createCommentTool();
+    const tool = createCommentTool(client);
     const result = await tool.execute("call-1", {
       action: "list",
       issueId: "ENG-1",

--- a/test/tools/linear-issue-tool.test.ts
+++ b/test/tools/linear-issue-tool.test.ts
@@ -1,61 +1,49 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { LinearClient } from "../../src/linear-client.js";
+import { createIssueTool } from "../../src/tools/linear-issue-tool.js";
 
-vi.mock("../../src/linear-api.js", () => ({
-  graphql: vi.fn(),
-  resolveIssueId: vi.fn(),
-  resolveTeamId: vi.fn(),
-  resolveStateId: vi.fn(),
-  resolveUserId: vi.fn(),
-  resolveLabelIds: vi.fn(),
-  resolveProjectId: vi.fn(),
-}));
-
-const {
-  graphql,
-  resolveIssueId,
-  resolveTeamId,
-  resolveStateId,
-  resolveUserId,
-  resolveLabelIds,
-  resolveProjectId,
-} = await import("../../src/linear-api.js");
-const { createIssueTool } = await import("../../src/tools/linear-issue-tool.js");
-
-const mockedGraphql = vi.mocked(graphql);
-const mockedResolveIssueId = vi.mocked(resolveIssueId);
-const mockedResolveTeamId = vi.mocked(resolveTeamId);
-const mockedResolveStateId = vi.mocked(resolveStateId);
-const mockedResolveUserId = vi.mocked(resolveUserId);
-const mockedResolveLabelIds = vi.mocked(resolveLabelIds);
-const mockedResolveProjectId = vi.mocked(resolveProjectId);
+function mockClient(): LinearClient {
+  return {
+    graphql: vi.fn(),
+    resolveIssueId: vi.fn(),
+    resolveTeamId: vi.fn(),
+    resolveStateId: vi.fn(),
+    resolveUserId: vi.fn(),
+    resolveLabelIds: vi.fn(),
+    resolveProjectId: vi.fn(),
+    _resetIssueIdCache: vi.fn(),
+  } as unknown as LinearClient;
+}
 
 function parse(result: { content: { type: string; text?: string }[] }) {
   const text = result.content.find((c) => c.type === "text")?.text;
   return text ? JSON.parse(text) : undefined;
 }
 
-beforeEach(() => {
-  vi.clearAllMocks();
-});
-
 describe("linear_issue tool", () => {
+  let client: ReturnType<typeof mockClient>;
+
+  beforeEach(() => {
+    client = mockClient();
+  });
+
   it("has correct name", () => {
-    const tool = createIssueTool();
+    const tool = createIssueTool(client);
     expect(tool.name).toBe("linear_issue");
   });
 
   describe("view", () => {
     it("returns issue details", async () => {
-      mockedResolveIssueId.mockResolvedValue("uuid-1");
+      vi.mocked(client.resolveIssueId).mockResolvedValue("uuid-1");
       const issue = {
         id: "uuid-1",
         identifier: "ENG-42",
         title: "Fix bug",
         state: { name: "Todo" },
       };
-      mockedGraphql.mockResolvedValue({ issue });
+      vi.mocked(client.graphql).mockResolvedValue({ issue });
 
-      const tool = createIssueTool();
+      const tool = createIssueTool(client);
       const result = await tool.execute("call-1", {
         action: "view",
         issueId: "ENG-42",
@@ -66,7 +54,7 @@ describe("linear_issue tool", () => {
     });
 
     it("returns error without issueId", async () => {
-      const tool = createIssueTool();
+      const tool = createIssueTool(client);
       const result = await tool.execute("call-1", { action: "view" });
       const data = parse(result);
       expect(data.error).toContain("issueId is required");
@@ -75,7 +63,7 @@ describe("linear_issue tool", () => {
 
   describe("list", () => {
     it("returns filtered issues", async () => {
-      mockedGraphql.mockResolvedValue({
+      vi.mocked(client.graphql).mockResolvedValue({
         issues: {
           nodes: [
             { id: "i1", identifier: "ENG-1", title: "Task 1" },
@@ -84,7 +72,7 @@ describe("linear_issue tool", () => {
         },
       });
 
-      const tool = createIssueTool();
+      const tool = createIssueTool(client);
       const result = await tool.execute("call-1", {
         action: "list",
         state: "In Progress",
@@ -95,11 +83,11 @@ describe("linear_issue tool", () => {
     });
 
     it("lists without filters", async () => {
-      mockedGraphql.mockResolvedValue({
+      vi.mocked(client.graphql).mockResolvedValue({
         issues: { nodes: [] },
       });
 
-      const tool = createIssueTool();
+      const tool = createIssueTool(client);
       const result = await tool.execute("call-1", { action: "list" });
       const data = parse(result);
       expect(data.issues).toEqual([]);
@@ -108,13 +96,13 @@ describe("linear_issue tool", () => {
 
   describe("create", () => {
     it("creates an issue with all fields", async () => {
-      mockedResolveTeamId.mockResolvedValue("team-1");
-      mockedResolveStateId.mockResolvedValue("state-1");
-      mockedResolveUserId.mockResolvedValue("user-1");
-      mockedResolveProjectId.mockResolvedValue("proj-1");
-      mockedResolveIssueId.mockResolvedValue("parent-uuid");
-      mockedResolveLabelIds.mockResolvedValue(["label-1"]);
-      mockedGraphql.mockResolvedValue({
+      vi.mocked(client.resolveTeamId).mockResolvedValue("team-1");
+      vi.mocked(client.resolveStateId).mockResolvedValue("state-1");
+      vi.mocked(client.resolveUserId).mockResolvedValue("user-1");
+      vi.mocked(client.resolveProjectId).mockResolvedValue("proj-1");
+      vi.mocked(client.resolveIssueId).mockResolvedValue("parent-uuid");
+      vi.mocked(client.resolveLabelIds).mockResolvedValue(["label-1"]);
+      vi.mocked(client.graphql).mockResolvedValue({
         issueCreate: {
           success: true,
           issue: {
@@ -126,7 +114,7 @@ describe("linear_issue tool", () => {
         },
       });
 
-      const tool = createIssueTool();
+      const tool = createIssueTool(client);
       const result = await tool.execute("call-1", {
         action: "create",
         title: "New issue",
@@ -145,14 +133,14 @@ describe("linear_issue tool", () => {
     });
 
     it("returns error without title", async () => {
-      const tool = createIssueTool();
+      const tool = createIssueTool(client);
       const result = await tool.execute("call-1", { action: "create" });
       const data = parse(result);
       expect(data.error).toContain("title is required");
     });
 
     it("fetches default team when none specified", async () => {
-      mockedGraphql
+      vi.mocked(client.graphql)
         .mockResolvedValueOnce({ teams: { nodes: [{ id: "default-team" }] } })
         .mockResolvedValueOnce({
           issueCreate: {
@@ -161,7 +149,7 @@ describe("linear_issue tool", () => {
           },
         });
 
-      const tool = createIssueTool();
+      const tool = createIssueTool(client);
       const result = await tool.execute("call-1", {
         action: "create",
         title: "Minimal",
@@ -173,8 +161,8 @@ describe("linear_issue tool", () => {
 
   describe("update", () => {
     it("updates issue fields", async () => {
-      mockedResolveIssueId.mockResolvedValue("uuid-1");
-      mockedGraphql
+      vi.mocked(client.resolveIssueId).mockResolvedValue("uuid-1");
+      vi.mocked(client.graphql)
         .mockResolvedValueOnce({ issue: { team: { id: "team-1" } } })
         .mockResolvedValueOnce({
           issueUpdate: {
@@ -182,9 +170,9 @@ describe("linear_issue tool", () => {
             issue: { id: "uuid-1", identifier: "ENG-42", title: "Updated" },
           },
         });
-      mockedResolveStateId.mockResolvedValue("state-done");
+      vi.mocked(client.resolveStateId).mockResolvedValue("state-done");
 
-      const tool = createIssueTool();
+      const tool = createIssueTool(client);
       const result = await tool.execute("call-1", {
         action: "update",
         issueId: "ENG-42",
@@ -196,7 +184,7 @@ describe("linear_issue tool", () => {
     });
 
     it("returns error without issueId", async () => {
-      const tool = createIssueTool();
+      const tool = createIssueTool(client);
       const result = await tool.execute("call-1", {
         action: "update",
         title: "No ID",
@@ -208,12 +196,12 @@ describe("linear_issue tool", () => {
 
   describe("delete", () => {
     it("deletes an issue", async () => {
-      mockedResolveIssueId.mockResolvedValue("uuid-1");
-      mockedGraphql.mockResolvedValue({
+      vi.mocked(client.resolveIssueId).mockResolvedValue("uuid-1");
+      vi.mocked(client.graphql).mockResolvedValue({
         issueDelete: { success: true },
       });
 
-      const tool = createIssueTool();
+      const tool = createIssueTool(client);
       const result = await tool.execute("call-1", {
         action: "delete",
         issueId: "ENG-42",
@@ -223,7 +211,7 @@ describe("linear_issue tool", () => {
     });
 
     it("returns error without issueId", async () => {
-      const tool = createIssueTool();
+      const tool = createIssueTool(client);
       const result = await tool.execute("call-1", { action: "delete" });
       const data = parse(result);
       expect(data.error).toContain("issueId is required");
@@ -231,9 +219,9 @@ describe("linear_issue tool", () => {
   });
 
   it("catches and returns errors from the API", async () => {
-    mockedResolveIssueId.mockRejectedValue(new Error("Network failure"));
+    vi.mocked(client.resolveIssueId).mockRejectedValue(new Error("Network failure"));
 
-    const tool = createIssueTool();
+    const tool = createIssueTool(client);
     const result = await tool.execute("call-1", {
       action: "view",
       issueId: "ENG-1",

--- a/test/tools/linear-project-tool.test.ts
+++ b/test/tools/linear-project-tool.test.ts
@@ -1,34 +1,40 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { LinearClient } from "../../src/linear-client.js";
+import { createProjectTool } from "../../src/tools/linear-project-tool.js";
 
-vi.mock("../../src/linear-api.js", () => ({
-  graphql: vi.fn(),
-  resolveTeamId: vi.fn(),
-}));
-
-const { graphql, resolveTeamId } = await import("../../src/linear-api.js");
-const { createProjectTool } = await import("../../src/tools/linear-project-tool.js");
-
-const mockedGraphql = vi.mocked(graphql);
-const mockedResolveTeamId = vi.mocked(resolveTeamId);
+function mockClient(): LinearClient {
+  return {
+    graphql: vi.fn(),
+    resolveIssueId: vi.fn(),
+    resolveTeamId: vi.fn(),
+    resolveStateId: vi.fn(),
+    resolveUserId: vi.fn(),
+    resolveLabelIds: vi.fn(),
+    resolveProjectId: vi.fn(),
+    _resetIssueIdCache: vi.fn(),
+  } as unknown as LinearClient;
+}
 
 function parse(result: { content: { type: string; text?: string }[] }) {
   const text = result.content.find((c) => c.type === "text")?.text;
   return text ? JSON.parse(text) : undefined;
 }
 
-beforeEach(() => {
-  vi.clearAllMocks();
-});
-
 describe("linear_project tool", () => {
+  let client: ReturnType<typeof mockClient>;
+
+  beforeEach(() => {
+    client = mockClient();
+  });
+
   it("has correct name", () => {
-    const tool = createProjectTool();
+    const tool = createProjectTool(client);
     expect(tool.name).toBe("linear_project");
   });
 
   describe("list", () => {
     it("returns projects", async () => {
-      mockedGraphql.mockResolvedValue({
+      vi.mocked(client.graphql).mockResolvedValue({
         projects: {
           nodes: [
             {
@@ -41,7 +47,7 @@ describe("linear_project tool", () => {
         },
       });
 
-      const tool = createProjectTool();
+      const tool = createProjectTool(client);
       const result = await tool.execute("call-1", { action: "list" });
       const data = parse(result);
       expect(data.projects).toHaveLength(1);
@@ -49,18 +55,18 @@ describe("linear_project tool", () => {
     });
 
     it("applies filters", async () => {
-      mockedGraphql.mockResolvedValue({
+      vi.mocked(client.graphql).mockResolvedValue({
         projects: { nodes: [] },
       });
 
-      const tool = createProjectTool();
+      const tool = createProjectTool(client);
       await tool.execute("call-1", {
         action: "list",
         team: "ENG",
         status: "planned",
       });
 
-      const query = mockedGraphql.mock.calls[0][0] as string;
+      const query = vi.mocked(client.graphql).mock.calls[0][0] as string;
       expect(query).toContain("status:");
       expect(query).toContain("$status");
       expect(query).toContain("$team");
@@ -69,7 +75,7 @@ describe("linear_project tool", () => {
 
   describe("view", () => {
     it("returns project details", async () => {
-      mockedGraphql.mockResolvedValue({
+      vi.mocked(client.graphql).mockResolvedValue({
         project: {
           id: "p1",
           name: "Alpha",
@@ -78,7 +84,7 @@ describe("linear_project tool", () => {
         },
       });
 
-      const tool = createProjectTool();
+      const tool = createProjectTool(client);
       const result = await tool.execute("call-1", {
         action: "view",
         projectId: "p1",
@@ -88,7 +94,7 @@ describe("linear_project tool", () => {
     });
 
     it("returns error without projectId", async () => {
-      const tool = createProjectTool();
+      const tool = createProjectTool(client);
       const result = await tool.execute("call-1", { action: "view" });
       const data = parse(result);
       expect(data.error).toContain("projectId is required");
@@ -97,15 +103,15 @@ describe("linear_project tool", () => {
 
   describe("create", () => {
     it("creates a project", async () => {
-      mockedResolveTeamId.mockResolvedValue("team-1");
-      mockedGraphql.mockResolvedValue({
+      vi.mocked(client.resolveTeamId).mockResolvedValue("team-1");
+      vi.mocked(client.graphql).mockResolvedValue({
         projectCreate: {
           success: true,
           project: { id: "p-new", name: "Beta", url: "https://linear.app/p" },
         },
       });
 
-      const tool = createProjectTool();
+      const tool = createProjectTool(client);
       const result = await tool.execute("call-1", {
         action: "create",
         name: "Beta",
@@ -118,7 +124,7 @@ describe("linear_project tool", () => {
     });
 
     it("returns error without name", async () => {
-      const tool = createProjectTool();
+      const tool = createProjectTool(client);
       const result = await tool.execute("call-1", { action: "create" });
       const data = parse(result);
       expect(data.error).toContain("name is required");
@@ -126,9 +132,9 @@ describe("linear_project tool", () => {
   });
 
   it("catches and returns API errors", async () => {
-    mockedGraphql.mockRejectedValue(new Error("Timeout"));
+    vi.mocked(client.graphql).mockRejectedValue(new Error("Timeout"));
 
-    const tool = createProjectTool();
+    const tool = createProjectTool(client);
     const result = await tool.execute("call-1", { action: "list" });
     const data = parse(result);
     expect(data.error).toContain("Timeout");

--- a/test/tools/linear-relation-tool.test.ts
+++ b/test/tools/linear-relation-tool.test.ts
@@ -1,35 +1,41 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { LinearClient } from "../../src/linear-client.js";
+import { createRelationTool } from "../../src/tools/linear-relation-tool.js";
 
-vi.mock("../../src/linear-api.js", () => ({
-  graphql: vi.fn(),
-  resolveIssueId: vi.fn(),
-}));
-
-const { graphql, resolveIssueId } = await import("../../src/linear-api.js");
-const { createRelationTool } = await import("../../src/tools/linear-relation-tool.js");
-
-const mockedGraphql = vi.mocked(graphql);
-const mockedResolveIssueId = vi.mocked(resolveIssueId);
+function mockClient(): LinearClient {
+  return {
+    graphql: vi.fn(),
+    resolveIssueId: vi.fn(),
+    resolveTeamId: vi.fn(),
+    resolveStateId: vi.fn(),
+    resolveUserId: vi.fn(),
+    resolveLabelIds: vi.fn(),
+    resolveProjectId: vi.fn(),
+    _resetIssueIdCache: vi.fn(),
+  } as unknown as LinearClient;
+}
 
 function parse(result: { content: { type: string; text?: string }[] }) {
   const text = result.content.find((c) => c.type === "text")?.text;
   return text ? JSON.parse(text) : undefined;
 }
 
-beforeEach(() => {
-  vi.clearAllMocks();
-});
-
 describe("linear_relation tool", () => {
+  let client: ReturnType<typeof mockClient>;
+
+  beforeEach(() => {
+    client = mockClient();
+  });
+
   it("has correct name", () => {
-    const tool = createRelationTool();
+    const tool = createRelationTool(client);
     expect(tool.name).toBe("linear_relation");
   });
 
   describe("list", () => {
     it("returns relations and inverse relations", async () => {
-      mockedResolveIssueId.mockResolvedValue("uuid-1");
-      mockedGraphql.mockResolvedValue({
+      vi.mocked(client.resolveIssueId).mockResolvedValue("uuid-1");
+      vi.mocked(client.graphql).mockResolvedValue({
         issue: {
           relations: {
             nodes: [
@@ -52,7 +58,7 @@ describe("linear_relation tool", () => {
         },
       });
 
-      const tool = createRelationTool();
+      const tool = createRelationTool(client);
       const result = await tool.execute("call-1", {
         action: "list",
         issueId: "ENG-1",
@@ -64,7 +70,7 @@ describe("linear_relation tool", () => {
     });
 
     it("returns error without issueId", async () => {
-      const tool = createRelationTool();
+      const tool = createRelationTool(client);
       const result = await tool.execute("call-1", { action: "list" });
       const data = parse(result);
       expect(data.error).toContain("issueId is required");
@@ -73,17 +79,17 @@ describe("linear_relation tool", () => {
 
   describe("add", () => {
     it("creates a blocks relation", async () => {
-      mockedResolveIssueId
+      vi.mocked(client.resolveIssueId)
         .mockResolvedValueOnce("uuid-1")
         .mockResolvedValueOnce("uuid-2");
-      mockedGraphql.mockResolvedValue({
+      vi.mocked(client.graphql).mockResolvedValue({
         issueRelationCreate: {
           success: true,
           issueRelation: { id: "r-new", type: "blocks" },
         },
       });
 
-      const tool = createRelationTool();
+      const tool = createRelationTool(client);
       const result = await tool.execute("call-1", {
         action: "add",
         issueId: "ENG-1",
@@ -95,17 +101,17 @@ describe("linear_relation tool", () => {
     });
 
     it("swaps direction for blocked-by", async () => {
-      mockedResolveIssueId
+      vi.mocked(client.resolveIssueId)
         .mockResolvedValueOnce("uuid-related") // relatedIssueId resolved first for blocked-by
         .mockResolvedValueOnce("uuid-issue");
-      mockedGraphql.mockResolvedValue({
+      vi.mocked(client.graphql).mockResolvedValue({
         issueRelationCreate: {
           success: true,
           issueRelation: { id: "r-new", type: "blocks" },
         },
       });
 
-      const tool = createRelationTool();
+      const tool = createRelationTool(client);
       await tool.execute("call-1", {
         action: "add",
         issueId: "ENG-1",
@@ -114,7 +120,7 @@ describe("linear_relation tool", () => {
       });
 
       // For blocked-by, issueId and relatedIssueId are swapped
-      const call = mockedGraphql.mock.calls[0];
+      const call = vi.mocked(client.graphql).mock.calls[0];
       const vars = call[1] as {
         input: { issueId: string; relatedIssueId: string; type: string };
       };
@@ -124,7 +130,7 @@ describe("linear_relation tool", () => {
     });
 
     it("returns error without required fields", async () => {
-      const tool = createRelationTool();
+      const tool = createRelationTool(client);
 
       let result = await tool.execute("call-1", { action: "add" });
       expect(parse(result).error).toContain("issueId is required");
@@ -146,11 +152,11 @@ describe("linear_relation tool", () => {
 
   describe("delete", () => {
     it("deletes a relation", async () => {
-      mockedGraphql.mockResolvedValue({
+      vi.mocked(client.graphql).mockResolvedValue({
         issueRelationDelete: { success: true },
       });
 
-      const tool = createRelationTool();
+      const tool = createRelationTool(client);
       const result = await tool.execute("call-1", {
         action: "delete",
         relationId: "r1",
@@ -160,7 +166,7 @@ describe("linear_relation tool", () => {
     });
 
     it("returns error without relationId", async () => {
-      const tool = createRelationTool();
+      const tool = createRelationTool(client);
       const result = await tool.execute("call-1", { action: "delete" });
       const data = parse(result);
       expect(data.error).toContain("relationId is required");
@@ -168,9 +174,9 @@ describe("linear_relation tool", () => {
   });
 
   it("catches and returns API errors", async () => {
-    mockedResolveIssueId.mockRejectedValue(new Error("Connection refused"));
+    vi.mocked(client.resolveIssueId).mockRejectedValue(new Error("Connection refused"));
 
-    const tool = createRelationTool();
+    const tool = createRelationTool(client);
     const result = await tool.execute("call-1", {
       action: "list",
       issueId: "ENG-1",

--- a/test/tools/linear-team-tool.test.ts
+++ b/test/tools/linear-team-tool.test.ts
@@ -1,32 +1,40 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { LinearClient } from "../../src/linear-client.js";
+import { createTeamTool } from "../../src/tools/linear-team-tool.js";
 
-vi.mock("../../src/linear-api.js", () => ({
-  graphql: vi.fn(),
-}));
-
-const { graphql } = await import("../../src/linear-api.js");
-const { createTeamTool } = await import("../../src/tools/linear-team-tool.js");
-
-const mockedGraphql = vi.mocked(graphql);
+function mockClient(): LinearClient {
+  return {
+    graphql: vi.fn(),
+    resolveIssueId: vi.fn(),
+    resolveTeamId: vi.fn(),
+    resolveStateId: vi.fn(),
+    resolveUserId: vi.fn(),
+    resolveLabelIds: vi.fn(),
+    resolveProjectId: vi.fn(),
+    _resetIssueIdCache: vi.fn(),
+  } as unknown as LinearClient;
+}
 
 function parse(result: { content: { type: string; text?: string }[] }) {
   const text = result.content.find((c) => c.type === "text")?.text;
   return text ? JSON.parse(text) : undefined;
 }
 
-beforeEach(() => {
-  vi.clearAllMocks();
-});
-
 describe("linear_team tool", () => {
+  let client: ReturnType<typeof mockClient>;
+
+  beforeEach(() => {
+    client = mockClient();
+  });
+
   it("has correct name", () => {
-    const tool = createTeamTool();
+    const tool = createTeamTool(client);
     expect(tool.name).toBe("linear_team");
   });
 
   describe("list", () => {
     it("returns all teams", async () => {
-      mockedGraphql.mockResolvedValue({
+      vi.mocked(client.graphql).mockResolvedValue({
         teams: {
           nodes: [
             { id: "t1", name: "Engineering", key: "ENG" },
@@ -35,7 +43,7 @@ describe("linear_team tool", () => {
         },
       });
 
-      const tool = createTeamTool();
+      const tool = createTeamTool(client);
       const result = await tool.execute("call-1", { action: "list" });
       const data = parse(result);
       expect(data.teams).toHaveLength(2);
@@ -45,7 +53,7 @@ describe("linear_team tool", () => {
 
   describe("members", () => {
     it("returns members of a team", async () => {
-      mockedGraphql.mockResolvedValue({
+      vi.mocked(client.graphql).mockResolvedValue({
         teams: {
           nodes: [
             {
@@ -60,7 +68,7 @@ describe("linear_team tool", () => {
         },
       });
 
-      const tool = createTeamTool();
+      const tool = createTeamTool(client);
       const result = await tool.execute("call-1", {
         action: "members",
         team: "ENG",
@@ -71,16 +79,16 @@ describe("linear_team tool", () => {
     });
 
     it("returns error without team", async () => {
-      const tool = createTeamTool();
+      const tool = createTeamTool(client);
       const result = await tool.execute("call-1", { action: "members" });
       const data = parse(result);
       expect(data.error).toContain("team is required");
     });
 
     it("returns error when team not found", async () => {
-      mockedGraphql.mockResolvedValue({ teams: { nodes: [] } });
+      vi.mocked(client.graphql).mockResolvedValue({ teams: { nodes: [] } });
 
-      const tool = createTeamTool();
+      const tool = createTeamTool(client);
       const result = await tool.execute("call-1", {
         action: "members",
         team: "NOPE",
@@ -91,9 +99,9 @@ describe("linear_team tool", () => {
   });
 
   it("catches and returns API errors", async () => {
-    mockedGraphql.mockRejectedValue(new Error("Network error"));
+    vi.mocked(client.graphql).mockRejectedValue(new Error("Network error"));
 
-    const tool = createTeamTool();
+    const tool = createTeamTool(client);
     const result = await tool.execute("call-1", { action: "list" });
     const data = parse(result);
     expect(data.error).toContain("Network error");

--- a/test/webhook-handler.test.ts
+++ b/test/webhook-handler.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createHmac } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { createWebhookHandler } from "../src/webhook-handler.js";
+import { WorkspaceRegistry } from "../src/workspace-registry.js";
 import type { IncomingMessage, ServerResponse } from "node:http";
 
 const SECRET = "test-webhook-secret";
@@ -10,8 +11,8 @@ function makeLogger() {
   return { info: vi.fn(), error: vi.fn() };
 }
 
-function sign(body: string): string {
-  return createHmac("sha256", SECRET).update(body).digest("hex");
+function sign(body: string, secret = SECRET): string {
+  return createHmac("sha256", secret).update(body).digest("hex");
 }
 
 function makeReq(
@@ -179,6 +180,7 @@ describe("webhook-handler", () => {
         updatedFrom: { assigneeId: null, priority: 3 },
         data: expect.objectContaining({ assigneeId: "user-1" }),
       }),
+      undefined,
     );
   });
 
@@ -198,6 +200,7 @@ describe("webhook-handler", () => {
 
     expect(onEvent).toHaveBeenCalledWith(
       expect.objectContaining({ updatedFrom: undefined }),
+      undefined,
     );
   });
 
@@ -219,5 +222,97 @@ describe("webhook-handler", () => {
     await handler(req, res);
     expect(res.statusCode).toBe(413);
     expect(res.body).toBe("Payload Too Large");
+  });
+});
+
+describe("webhook-handler with registry", () => {
+  let logger: ReturnType<typeof makeLogger>;
+  let registry: WorkspaceRegistry;
+
+  beforeEach(() => {
+    logger = makeLogger();
+    registry = new WorkspaceRegistry();
+  });
+
+  it("matches workspace A by signature", async () => {
+    registry.register(
+      { id: "ws-A", apiKey: "key-A", webhookSecret: "secret-A", agentMapping: {} },
+      logger,
+    );
+    registry.register(
+      { id: "ws-B", apiKey: "key-B", webhookSecret: "secret-B", agentMapping: {} },
+      logger,
+    );
+
+    const onEvent = vi.fn();
+    const handler = createWebhookHandler({ registry, logger, onEvent });
+
+    const body = JSON.stringify({
+      action: "create",
+      type: "Issue",
+      data: { id: "i1" },
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    const req = makeReq(body, { "Linear-Signature": sign(body, "secret-A") });
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "Issue" }),
+      expect.objectContaining({ config: expect.objectContaining({ id: "ws-A" }) }),
+    );
+  });
+
+  it("matches workspace B by signature", async () => {
+    registry.register(
+      { id: "ws-A", apiKey: "key-A", webhookSecret: "secret-A", agentMapping: {} },
+      logger,
+    );
+    registry.register(
+      { id: "ws-B", apiKey: "key-B", webhookSecret: "secret-B", agentMapping: {} },
+      logger,
+    );
+
+    const onEvent = vi.fn();
+    const handler = createWebhookHandler({ registry, logger, onEvent });
+
+    const body = JSON.stringify({
+      action: "update",
+      type: "Comment",
+      data: { id: "c1" },
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    const req = makeReq(body, { "Linear-Signature": sign(body, "secret-B") });
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ config: expect.objectContaining({ id: "ws-B" }) }),
+    );
+  });
+
+  it("returns 400 when signature matches no workspace", async () => {
+    registry.register(
+      { id: "ws-A", apiKey: "key-A", webhookSecret: "secret-A", agentMapping: {} },
+      logger,
+    );
+
+    const handler = createWebhookHandler({ registry, logger });
+
+    const body = JSON.stringify({
+      action: "create",
+      type: "Issue",
+      data: { id: "i1" },
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    const req = makeReq(body, { "Linear-Signature": sign(body, "wrong-secret") });
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toBe("Invalid signature");
   });
 });

--- a/test/work-queue.test.ts
+++ b/test/work-queue.test.ts
@@ -28,8 +28,11 @@ function entry(
   event: string,
   summary: string,
   issuePriority = 0,
+  workspaceId?: string,
 ): EnqueueEntry {
-  return { id, event, summary, issuePriority };
+  const e: EnqueueEntry = { id, event, summary, issuePriority };
+  if (workspaceId) e.workspaceId = workspaceId;
+  return e;
 }
 
 beforeEach(() => {
@@ -586,5 +589,60 @@ describe("InboxQueue mutex serialization", () => {
     const onDisk = readItems();
     expect(onDisk).toHaveLength(2);
     expect(onDisk.every((i) => i.status === "in_progress")).toBe(true);
+  });
+});
+
+// --- Cross-workspace dedup isolation ---
+
+describe("InboxQueue cross-workspace dedup", () => {
+  it("allows same issue ID from different workspaces", async () => {
+    const queue = new InboxQueue(QUEUE_PATH);
+    const added1 = await queue.enqueue([
+      entry("ENG-42", "issue.assigned", "Fix bug (ws-A)", 2, "ws-A"),
+    ]);
+    const added2 = await queue.enqueue([
+      entry("ENG-42", "issue.assigned", "Fix bug (ws-B)", 2, "ws-B"),
+    ]);
+
+    expect(added1).toBe(1);
+    expect(added2).toBe(1);
+
+    const items = readItems();
+    expect(items).toHaveLength(2);
+    expect(items[0].workspaceId).toBe("ws-A");
+    expect(items[1].workspaceId).toBe("ws-B");
+  });
+
+  it("deduplicates same issue ID within same workspace", async () => {
+    const queue = new InboxQueue(QUEUE_PATH);
+    await queue.enqueue([
+      entry("ENG-42", "issue.assigned", "Fix bug", 2, "ws-A"),
+    ]);
+    const added = await queue.enqueue([
+      entry("ENG-42", "issue.assigned", "Fix bug", 2, "ws-A"),
+    ]);
+
+    expect(added).toBe(0);
+    expect(readItems()).toHaveLength(1);
+  });
+
+  it("items without workspaceId use 'default' for dedup", async () => {
+    const queue = new InboxQueue(QUEUE_PATH);
+    await queue.enqueue([entry("ENG-42", "issue.assigned", "Fix bug", 2)]);
+    const added = await queue.enqueue([entry("ENG-42", "issue.assigned", "Fix bug", 2)]);
+
+    expect(added).toBe(0);
+    expect(readItems()).toHaveLength(1);
+  });
+
+  it("workspace items don't collide with default items", async () => {
+    const queue = new InboxQueue(QUEUE_PATH);
+    await queue.enqueue([entry("ENG-42", "issue.assigned", "Fix bug", 2)]);
+    const added = await queue.enqueue([
+      entry("ENG-42", "issue.assigned", "Fix bug (ws-A)", 2, "ws-A"),
+    ]);
+
+    expect(added).toBe(1);
+    expect(readItems()).toHaveLength(2);
   });
 });

--- a/test/workspace-registry.test.ts
+++ b/test/workspace-registry.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createHmac } from "node:crypto";
+import { WorkspaceRegistry, type WorkspaceConfig } from "../src/workspace-registry.js";
+
+function makeLogger() {
+  return { info: vi.fn(), error: vi.fn() };
+}
+
+function sign(body: string, secret: string): string {
+  return createHmac("sha256", secret).update(body).digest("hex");
+}
+
+function makeWorkspaceConfig(overrides: Partial<WorkspaceConfig> = {}): WorkspaceConfig {
+  return {
+    id: "ws-1",
+    apiKey: "lin_api_ws1",
+    webhookSecret: "secret-ws1",
+    agentMapping: { "user-uuid-1": "agent-1" },
+    ...overrides,
+  };
+}
+
+describe("WorkspaceRegistry", () => {
+  let registry: WorkspaceRegistry;
+  let logger: ReturnType<typeof makeLogger>;
+
+  beforeEach(() => {
+    registry = new WorkspaceRegistry();
+    logger = makeLogger();
+  });
+
+  describe("register and get", () => {
+    it("registers and retrieves a workspace by id", () => {
+      const config = makeWorkspaceConfig();
+      registry.register(config, logger);
+
+      const ws = registry.get("ws-1");
+      expect(ws).toBeDefined();
+      expect(ws!.config.id).toBe("ws-1");
+      expect(ws!.client).toBeDefined();
+      expect(ws!.routeEvent).toBeTypeOf("function");
+    });
+
+    it("returns undefined for unknown id", () => {
+      expect(registry.get("unknown")).toBeUndefined();
+    });
+
+    it("reports correct size", () => {
+      expect(registry.size).toBe(0);
+      registry.register(makeWorkspaceConfig({ id: "a" }), logger);
+      expect(registry.size).toBe(1);
+      registry.register(makeWorkspaceConfig({ id: "b" }), logger);
+      expect(registry.size).toBe(2);
+    });
+  });
+
+  describe("getDefault", () => {
+    it("returns the first registered workspace", () => {
+      registry.register(makeWorkspaceConfig({ id: "first" }), logger);
+      registry.register(makeWorkspaceConfig({ id: "second" }), logger);
+
+      const ws = registry.getDefault();
+      expect(ws).toBeDefined();
+      expect(ws!.config.id).toBe("first");
+    });
+
+    it("returns undefined when empty", () => {
+      expect(registry.getDefault()).toBeUndefined();
+    });
+  });
+
+  describe("all", () => {
+    it("returns all registered workspaces", () => {
+      registry.register(makeWorkspaceConfig({ id: "a" }), logger);
+      registry.register(makeWorkspaceConfig({ id: "b" }), logger);
+
+      const all = registry.all();
+      expect(all).toHaveLength(2);
+      expect(all.map((w) => w.config.id)).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("matchBySignature", () => {
+    it("matches the correct workspace by HMAC signature", () => {
+      registry.register(makeWorkspaceConfig({ id: "ws-A", webhookSecret: "secret-A" }), logger);
+      registry.register(makeWorkspaceConfig({ id: "ws-B", webhookSecret: "secret-B" }), logger);
+
+      const body = '{"action":"create","type":"Issue"}';
+      const sigA = sign(body, "secret-A");
+      const sigB = sign(body, "secret-B");
+
+      expect(registry.matchBySignature(body, sigA)!.config.id).toBe("ws-A");
+      expect(registry.matchBySignature(body, sigB)!.config.id).toBe("ws-B");
+    });
+
+    it("returns null for invalid signature", () => {
+      registry.register(makeWorkspaceConfig({ webhookSecret: "real-secret" }), logger);
+
+      const body = '{"action":"create","type":"Issue"}';
+      const badSig = sign(body, "wrong-secret");
+
+      expect(registry.matchBySignature(body, badSig)).toBeNull();
+    });
+
+    it("returns null when no workspaces registered", () => {
+      expect(registry.matchBySignature("body", "sig")).toBeNull();
+    });
+  });
+
+  describe("resolveByAgentId", () => {
+    it("resolves workspace from agent mapping", () => {
+      registry.register(
+        makeWorkspaceConfig({
+          id: "ws-X",
+          agentMapping: { "uuid-1": "titus", "uuid-2": "scout" },
+        }),
+        logger,
+      );
+      registry.register(
+        makeWorkspaceConfig({
+          id: "ws-Y",
+          agentMapping: { "uuid-3": "other-agent" },
+        }),
+        logger,
+      );
+
+      expect(registry.resolveByAgentId("titus")!.config.id).toBe("ws-X");
+      expect(registry.resolveByAgentId("scout")!.config.id).toBe("ws-X");
+      expect(registry.resolveByAgentId("other-agent")!.config.id).toBe("ws-Y");
+    });
+
+    it("returns undefined for unknown agent", () => {
+      registry.register(
+        makeWorkspaceConfig({ agentMapping: { "uuid-1": "titus" } }),
+        logger,
+      );
+      expect(registry.resolveByAgentId("unknown-agent")).toBeUndefined();
+    });
+  });
+
+  describe("routeEvent", () => {
+    it("uses workspace-specific event router", () => {
+      registry.register(
+        makeWorkspaceConfig({
+          id: "ws-filtered",
+          agentMapping: { "user-1": "agent-1" },
+          eventFilter: ["Comment"], // Only Comment events
+        }),
+        logger,
+      );
+
+      const ws = registry.get("ws-filtered")!;
+
+      // Issue events should be filtered out
+      const issueActions = ws.routeEvent({
+        action: "create",
+        type: "Issue",
+        data: { id: "i1", assigneeId: "user-1", identifier: "ENG-1" },
+        createdAt: "2026-01-01T00:00:00Z",
+      });
+      expect(issueActions).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add multi-workspace support allowing a single plugin instance to serve multiple Linear workspaces with separate API keys, webhook secrets, and agent mappings
- Workspace is auto-detected by trying each workspace's HMAC secret against the incoming webhook signature
- Single-workspace configs (flat `apiKey`/`webhookSecret`) remain fully backward compatible — wrapped into a `"default"` workspace internally

## Changes

- **`src/linear-client.ts`** (new) — `LinearClient` class extracted from `linear-api.ts` with per-instance API key and issue ID cache
- **`src/workspace-registry.ts`** (new) — `WorkspaceRegistry` with `matchBySignature`, `resolveByAgentId`, workspace-scoped event routers
- **`src/linear-api.ts`** — converted to compatibility shim delegating to a default `LinearClient`
- **`src/tools/*.ts`** — all 5 tool factories now accept a `LinearClient` parameter
- **`src/index.ts`** — full integration: parses `workspaces` array or wraps flat config, registers tools via `OpenClawPluginToolFactory`, session→workspace mapping
- **`src/webhook-handler.ts`** — accepts either `webhookSecret` or `WorkspaceRegistry`; passes matched `Workspace` to `onEvent`
- **`src/event-router.ts`** / **`src/work-queue.ts`** — added `workspaceId` field for cross-workspace dedup isolation
- **`openclaw.plugin.json`** — added `workspaces` array schema, relaxed top-level required constraints

## Test plan

- [x] All 219 tests pass (40 new tests added)
- [x] `test/linear-client.test.ts` — LinearClient class with independent caches per instance
- [x] `test/workspace-registry.test.ts` — registration, signature matching, agentId reverse lookup, workspace-scoped routing
- [x] `test/webhook-handler.test.ts` — multi-workspace signature matching (workspace A, B, invalid)
- [x] `test/work-queue.test.ts` — cross-workspace dedup isolation (same issue ID, different workspaces)
- [x] All existing tool tests updated to pass mock `LinearClient` instead of module mocks
- [x] Clean TypeScript build (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-workspace support, enabling management of multiple Linear workspaces within a single plugin configuration
  * Workspace configurations now support independent API keys, webhook secrets, team filtering, and event routing
  * Events are automatically routed to the correct workspace based on webhook signature verification
  * Maintains backward compatibility with existing single-workspace configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->