### PR TITLE
fix: multi-secret webhook verification, self-comment skip, and data fallback

### DIFF
--- a/src/event-router.ts
+++ b/src/event-router.ts
@@ -380,6 +380,19 @@ function handleComment(
     return [];
   }
 
+  // Skip comments authored by mapped agents to prevent webhook loops.
+  // When an agent posts a comment via the Linear API, the webhook fires
+  // back with the agent's userId as the comment author. Without this
+  // check, the agent would be woken up by its own comment.
+  const commentUserId = (event.data.user as Record<string, unknown> | undefined)?.id as string | undefined
+    ?? event.data.userId as string | undefined;
+  if (commentUserId && config.agentMapping[commentUserId]) {
+    config.logger.info(
+      `Skipping self-comment from agent ${config.agentMapping[commentUserId]} on ${String(event.data.id ?? "unknown")}`,
+    );
+    return [];
+  }
+
   const commentId = String(event.data.id ?? "");
   const bodyData = event.data.bodyData;
   const mentionedIds = extractMentionedUserIds(body, bodyData, config.agentMapping);

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -11,7 +11,7 @@ export type LinearWebhookPayload = {
 };
 
 type WebhookHandlerDeps = {
-  webhookSecret: string;
+  webhookSecret: string | string[];
   logger: {
     info: (message: string) => void;
     error: (message: string) => void;
@@ -93,7 +93,9 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
     }
 
     const signature = req.headers["linear-signature"];
-    if (typeof signature !== "string" || !verifySignature(rawBody, signature, deps.webhookSecret)) {
+    const secrets = Array.isArray(deps.webhookSecret) ? deps.webhookSecret : [deps.webhookSecret];
+    const signatureValid = typeof signature === "string" && secrets.some((s) => verifySignature(rawBody, signature, s));
+    if (!signatureValid) {
       res.writeHead(400);
       res.end("Invalid signature");
       return;
@@ -120,7 +122,10 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
       event = {
         action: String(payload.action ?? ""),
         type: String(payload.type ?? ""),
-        data: (payload.data as Record<string, unknown>) ?? {},
+        // Some Linear webhook payloads (e.g. OAuth App events) place fields
+        // directly on the top-level object instead of nesting under `data`.
+        // Fall back to the full payload so downstream handlers still see data.
+        data: (payload.data as Record<string, unknown>) ?? payload,
         updatedFrom: (payload.updatedFrom as Record<string, unknown>) ?? undefined,
         createdAt: String(payload.createdAt ?? ""),
       };

--- a/test/event-router.test.ts
+++ b/test/event-router.test.ts
@@ -858,6 +858,74 @@ describe("event-router", () => {
     });
   });
 
+  describe("self-comment skip", () => {
+    it("skips comments authored by a mapped agent (user field)", () => {
+      const config = makeConfig();
+      const route = createEventRouter(config);
+
+      const event: LinearWebhookPayload = {
+        type: "Comment",
+        action: "create",
+        data: {
+          id: "comment-self-1",
+          body: "Hey @user-2 what do you think?",
+          user: { id: "user-1" },
+          issue: { id: "issue-600" },
+        },
+        createdAt: new Date().toISOString(),
+      };
+
+      // user-1 is a mapped agent, so this comment should be skipped
+      const actions = route(event);
+      expect(actions).toEqual([]);
+      expect(config.logger.info).toHaveBeenCalledWith(
+        expect.stringContaining("Skipping self-comment from agent agent-1"),
+      );
+    });
+
+    it("skips comments authored by a mapped agent (userId field)", () => {
+      const config = makeConfig();
+      const route = createEventRouter(config);
+
+      const event: LinearWebhookPayload = {
+        type: "Comment",
+        action: "create",
+        data: {
+          id: "comment-self-2",
+          body: "Hey @user-2 thoughts?",
+          userId: "user-1",
+          issue: { id: "issue-601" },
+        },
+        createdAt: new Date().toISOString(),
+      };
+
+      const actions = route(event);
+      expect(actions).toEqual([]);
+    });
+
+    it("does not skip comments from non-agent users", () => {
+      const config = makeConfig();
+      const route = createEventRouter(config);
+
+      const event: LinearWebhookPayload = {
+        type: "Comment",
+        action: "create",
+        data: {
+          id: "comment-human",
+          body: "Hey @user-1 can you check?",
+          user: { id: "human-user-123" },
+          issue: { id: "issue-602" },
+        },
+        createdAt: new Date().toISOString(),
+      };
+
+      // human-user-123 is NOT in agentMapping, so the comment should be routed
+      const actions = route(event);
+      expect(actions).toHaveLength(1);
+      expect(actions[0].agentId).toBe("agent-1");
+    });
+  });
+
   describe("unrelated events", () => {
     it("returns empty for non-issue non-comment events", () => {
       const config = makeConfig();

--- a/test/webhook-handler.test.ts
+++ b/test/webhook-handler.test.ts
@@ -201,6 +201,65 @@ describe("webhook-handler", () => {
     );
   });
 
+  it("accepts signature when webhookSecret is an array", async () => {
+    const secrets = ["secret-a", "secret-b", SECRET];
+    const h = createWebhookHandler({ webhookSecret: secrets, logger });
+
+    const body = JSON.stringify({
+      action: "create",
+      type: "Issue",
+      data: { id: "issue-multi" },
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    // Sign with SECRET (the third secret)
+    const req = makeReq(body, { "Linear-Signature": sign(body) });
+    const res = makeRes();
+    await h(req, res);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("rejects signature when none of the secrets match", async () => {
+    const secrets = ["secret-a", "secret-b"];
+    const h = createWebhookHandler({ webhookSecret: secrets, logger });
+
+    const body = JSON.stringify({
+      action: "create",
+      type: "Issue",
+      data: { id: "issue-bad" },
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    // Sign with SECRET which is NOT in the array
+    const req = makeReq(body, { "Linear-Signature": sign(body) });
+    const res = makeRes();
+    await h(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("falls back to full payload when data field is missing", async () => {
+    const onEvent = vi.fn();
+    const h = createWebhookHandler({ webhookSecret: SECRET, logger, onEvent });
+
+    // Simulate an OAuth App webhook that has no nested `data` field
+    const body = JSON.stringify({
+      action: "create",
+      type: "AgentSession",
+      id: "session-1",
+      agentId: "agent-1",
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    const req = makeReq(body, { "Linear-Signature": sign(body) });
+    const res = makeRes();
+    await h(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(onEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        // data should be the full payload since payload.data is undefined
+        data: expect.objectContaining({ id: "session-1", agentId: "agent-1" }),
+      }),
+    );
+  });
+
   it("returns 413 for oversized request body", async () => {
     const req = new EventEmitter() as IncomingMessage;
     req.method = "POST";


### PR DESCRIPTION
## Summary

Three targeted fixes for real-world multi-agent deployments with both workspace and OAuth App webhooks.

### Changes

#### 1. Multi-secret webhook signature verification
**Problem**: Deployments receiving webhooks from multiple sources (workspace webhook + OAuth App webhooks) use different signing keys, but `webhookSecret` only accepted a single string.

**Fix**: `webhookSecret` now accepts `string | string[]`. When an array is provided, each secret is tried until one matches. Single-string behavior is unchanged (fully backwards compatible).

#### 2. Self-comment skip in event router  
**Problem**: When an agent posts a comment via the Linear API, the webhook fires back with the agent's userId as the comment author. Without filtering, the agent wakes itself up in an infinite loop.

**Fix**: `handleComment()` now checks if the comment author (`user.id` or `userId`) is a mapped agent in `agentMapping`. If so, the comment is skipped with an info log.

#### 3. Payload data fallback
**Problem**: Some OAuth App webhook events (e.g. `AgentSessionEvent`) place fields directly on the top-level payload instead of nesting under `data`. The existing `payload.data ?? {}` returned an empty object, losing all event data.

**Fix**: Falls back to the full `payload` object when `payload.data` is undefined, so downstream handlers can still access event fields.

### Testing

- 6 new tests added (3 for webhook handler, 3 for event router)
- All 185 tests pass
- Verified in production with 9 OAuth agents across 14-agent deployment

### Backwards Compatibility

All changes are fully backwards compatible:
- Single `webhookSecret` string still works identically
- Self-comment skip only activates for users in `agentMapping`
- Data fallback only triggers when `payload.data` is `undefined`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Webhook handlers now support multiple secrets for signature verification, enabling flexible secret rotation and multi-environment deployments.

* **Bug Fixes**
  * Comments from configured agents are now properly skipped to prevent duplicate message processing.
  * Improved webhook payload handling for cases where nested data structures are absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->