### PR TITLE
docs: add TweetClaw Linear intake workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,11 @@ Thanks for your interest in contributing to openclaw-linear!
 
 ## Reporting Bugs
 
-Use the [bug report template](https://github.com/nichochar/openclaw-linear/issues/new?template=bug_report.md) and include steps to reproduce.
+Use the [bug report template](https://github.com/stepandel/openclaw-linear/issues/new?template=bug_report.md) and include steps to reproduce.
 
 ## Suggesting Features
 
-Open an issue using the [feature request template](https://github.com/nichochar/openclaw-linear/issues/new?template=feature_request.md).
+Open an issue using the [feature request template](https://github.com/stepandel/openclaw-linear/issues/new?template=feature_request.md).
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # openclaw-linear
 
-Linear integration for [OpenClaw](https://github.com/nichochar/openclaw). Receives Linear webhook events, routes them through a persistent work queue, and gives agents tools to manage issues, comments, projects, teams, and relations via the Linear GraphQL API.
+Linear integration for [OpenClaw](https://github.com/openclaw/openclaw). Receives Linear webhook events, routes them through a persistent work queue, and gives agents tools to manage issues, comments, projects, teams, and relations via the Linear GraphQL API.
 
 ## Install
 
@@ -59,6 +59,22 @@ plugins:
    - Save
 
 3. **Verify:** Assign a Linear issue to a mapped user — the agent should receive a notification.
+
+## Optional X/Twitter Intake
+
+Use [TweetClaw](https://github.com/Xquik-dev/tweetclaw) beside openclaw-linear when Linear work needs public X/Twitter evidence or launch follow-up. Linear remains the issue queue and project system; TweetClaw handles X/Twitter automation through structured OpenClaw tools.
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+Useful handoff pattern:
+
+1. Use TweetClaw to search tweets, search tweet replies, export followers, look up users, monitor tweets, collect media references, or run giveaway draws.
+2. Create or update the Linear issue with the source query, tweet IDs or URLs, capture date, concise summary, confidence, and next action.
+3. Use approval-gated TweetClaw actions only when the Linear work item explicitly calls for posting tweets or tweet replies.
+
+Links: [GitHub](https://github.com/Xquik-dev/tweetclaw), [npm](https://www.npmjs.com/package/@xquik/tweetclaw), [ClawHub](https://clawhub.ai/plugins/@xquik/tweetclaw).
 
 ## How It Works
 

--- a/skills/linear/SKILL.md
+++ b/skills/linear/SKILL.md
@@ -129,3 +129,9 @@ When you receive a Linear notification:
    - `mention` — read the thread and reply with `linear_comment { action: "add", ... }`.
 7. **Complete** with `linear_queue { action: "complete", issueId: "<id>" }` to remove it from the queue.
 8. **Repeat** from step 3 until pop returns null.
+
+## Optional X/Twitter evidence
+
+If a Linear item asks for public X/Twitter research and TweetClaw is also installed, use TweetClaw for search tweets, search tweet replies, follower export, user lookup, media references, monitors, webhooks, giveaway draws, and approval-gated post tweet or reply actions. Keep openclaw-linear responsible for the Linear queue, issue updates, and comments.
+
+When adding TweetClaw findings to Linear, include the source query, tweet IDs or URLs, capture date, concise summary, confidence, and next action. Do not paste raw timelines, account credentials, or direct-message contents into Linear unless the workspace policy explicitly allows it.


### PR DESCRIPTION
## Summary

- Adds an optional TweetClaw intake workflow for Linear work that needs public X/Twitter evidence or launch follow-up.
- Shows the exact `openclaw plugins install @xquik/tweetclaw` command plus canonical GitHub, npm, and ClawHub links.
- Updates stale contribution links from the old `nichochar/openclaw-linear` path to this repository.

## Duplicate checks

Searched this repository and open/closed PRs and issues for TweetClaw, tweetclaw, @xquik/tweetclaw, Xquik, x-twitter-scraper, the TweetClaw GitHub URL, npm package URL, and ClawHub URL. No existing TweetClaw or Xquik thread was found.

## Validation

- `git diff --check`
- Added-line scan for secrets, Context7, and dash issues
- Scoped public-link check for README, CONTRIBUTING, skill docs, package metadata, and OpenClaw manifest. The npm package page returns bot-protection 403 locally, but the npm registry metadata for `@xquik/tweetclaw` returns 200.
- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm run build`
- `npm test` passes 202 tests. It emits existing local OpenClaw config warnings from `/Users/burak/.openclaw/openclaw.json`, but no test fails.
- `npm pack --dry-run --json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated bug report and feature request template links in contribution guidelines
- Added X/Twitter integration documentation for the optional TweetClaw plugin, including installation and workflow guidance
- Added instructions for handling X/Twitter evidence in Linear workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stepandel/openclaw-linear/pull/26)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->