### PR TITLE
Ready for maintainer merge: Restore webhook source secret handling coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ plugins:
     #   source: "env"
     #   provider: "process"
     #   id: "LINEAR_WEBHOOK_SECRET"
+    # SecretRef requires an OpenClaw host that resolves secretInputs before activation.
     agentMapping:                        # Filter: only handle events for these Linear users
       "linear-user-uuid": "titus"
     teamIds: ["ENG", "OPS"]             # Optional: filter to specific teams (empty = all)
@@ -41,7 +42,7 @@ plugins:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `apiKey` | string | **Yes** | Linear API key. Create at [linear.app/settings/account/security](https://linear.app/settings/account/security). |
-| `webhookSecret` | string or SecretRef | **Yes** | Shared secret for HMAC webhook signature verification. SecretRef values are resolved by OpenClaw runtime secret input handling before the webhook handler receives them. |
+| `webhookSecret` | string or SecretRef | **Yes** | Shared secret for HMAC webhook signature verification. SecretRef values require OpenClaw runtime secret input handling and must be resolved to a non-empty string before plugin activation. Use a string value on hosts without SecretRef resolution. |
 | `agentMapping` | object | No | Maps Linear user UUIDs to agent IDs. Acts as a filter — events for unmapped users are ignored. Since each instance runs one agent, this typically has one entry. |
 | `teamIds` | string[] | No | Team keys to scope webhook processing. Empty = all teams. |
 | `eventFilter` | string[] | No | Event types to handle (`Issue`, `Comment`). Empty = all. |

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ plugins:
   linear:
     apiKey: "lin_api_..."                # Linear API key (required)
     webhookSecret: "your-signing-secret" # Webhook secret (required)
+    # Or resolve the webhook secret at runtime:
+    # webhookSecret:
+    #   source: "env"
+    #   provider: "process"
+    #   id: "LINEAR_WEBHOOK_SECRET"
     agentMapping:                        # Filter: only handle events for these Linear users
       "linear-user-uuid": "titus"
     teamIds: ["ENG", "OPS"]             # Optional: filter to specific teams (empty = all)
@@ -36,7 +41,7 @@ plugins:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `apiKey` | string | **Yes** | Linear API key. Create at [linear.app/settings/account/security](https://linear.app/settings/account/security). |
-| `webhookSecret` | string | **Yes** | Shared secret for HMAC webhook signature verification. |
+| `webhookSecret` | string or SecretRef | **Yes** | Shared secret for HMAC webhook signature verification. SecretRef values are resolved by OpenClaw runtime secret input handling before the webhook handler receives them. |
 | `agentMapping` | object | No | Maps Linear user UUIDs to agent IDs. Acts as a filter — events for unmapped users are ignored. Since each instance runs one agent, this typically has one entry. |
 | `teamIds` | string[] | No | Team keys to scope webhook processing. Empty = all teams. |
 | `eventFilter` | string[] | No | Event types to handle (`Issue`, `Comment`). Empty = all. |
@@ -54,7 +59,7 @@ plugins:
 2. **Register the webhook in Linear:**
    - Go to **Settings > API > Webhooks**
    - Set the URL to `https://your-host/hooks/linear`
-   - Set the secret to match your `webhookSecret`
+   - Set the secret to match the resolved value of your `webhookSecret`
    - Select event types: Issues, Comments
    - Save
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -6,6 +6,33 @@
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
+    "$defs": {
+      "secretRef": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "source": {
+            "type": "string",
+            "enum": [
+              "env",
+              "file",
+              "exec"
+            ]
+          },
+          "provider": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "source",
+          "provider",
+          "id"
+        ]
+      }
+    },
     "properties": {
       "apiKey": {
         "type": "string",
@@ -13,7 +40,15 @@
         "description": "Linear API key for authentication (create at linear.app/settings/account/security)"
       },
       "webhookSecret": {
-        "type": "string",
+        "anyOf": [
+          {
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "$ref": "#/$defs/secretRef"
+          }
+        ],
         "sensitive": true,
         "description": "Webhook signing secret for HMAC verification"
       },
@@ -43,5 +78,15 @@
       }
     },
     "required": ["webhookSecret", "apiKey"]
+  },
+  "configContracts": {
+    "secretInputs": {
+      "paths": [
+        {
+          "path": "webhookSecret",
+          "expected": "string"
+        }
+      ]
+    }
   }
 }

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -20,10 +20,12 @@
             ]
           },
           "provider": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "id": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           }
         },
         "required": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,6 +128,16 @@ async function dispatchConsolidatedActions(
 let activeDebouncer: { flushKey: (key: string) => Promise<void> } | undefined;
 const activeDebouncerKeys = new Set<string>();
 
+function isSecretRefConfig(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return typeof record.source === "string"
+    && typeof record.provider === "string"
+    && typeof record.id === "string";
+}
+
 export function activate(api: OpenClawPluginApi): void {
   api.logger.info("Linear plugin activated");
 
@@ -139,6 +149,10 @@ export function activate(api: OpenClawPluginApi): void {
   setApiKey(linearApiKey);
 
   const webhookSecret = api.pluginConfig?.["webhookSecret"];
+  if (isSecretRefConfig(webhookSecret)) {
+    api.logger.error("[linear] webhookSecret SecretRef was not resolved by the OpenClaw runtime — plugin is inert");
+    return;
+  }
   if (typeof webhookSecret !== "string" || !webhookSecret) {
     api.logger.error("[linear] webhookSecret is not configured — plugin is inert");
     return;

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -1,4 +1,4 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
@@ -17,11 +17,83 @@ type WebhookHandlerDeps = {
     error: (message: string) => void;
   };
   onEvent?: (event: LinearWebhookPayload) => void;
+  onStatus?: (status: LinearWebhookStatus) => void;
+};
+
+export type LinearWebhookStatus = {
+  schemaVersion: "linear.webhook_status.v1";
+  observedAt: string;
+  classification:
+    | "accepted_ingress"
+    | "duplicate_replay"
+    | "invalid_refusal"
+    | "unavailable_state";
+  state: "accepted" | "duplicate" | "refused" | "unavailable";
+  reason: string;
+  eventClass: string;
+  issueKey?: string;
+  deliveryHash?: string;
+  httpStatus?: number;
 };
 
 const MAX_BODY_BYTES = 1024 * 1024; // 1 MB
 const DEDUP_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const DEDUP_MAX_SIZE = 10_000;
+const ALLOWED_EVENT_ACTIONS: Record<string, Set<string>> = {
+  Issue: new Set(["create", "update", "remove"]),
+  Comment: new Set(["create", "update"]),
+};
+
+function objectRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function validatePayloadShape(payload: unknown): { ok: boolean; action: string; type: string } {
+  const record = objectRecord(payload);
+  const action = String(record.action ?? "");
+  const type = String(record.type ?? "");
+  const allowedActions = ALLOWED_EVENT_ACTIONS[type];
+  if (!allowedActions || !allowedActions.has(action)) {
+    return { ok: false, action, type };
+  }
+  return { ok: true, action, type };
+}
+
+function deliveryHash(deliveryId: string): string {
+  return `sha256:${createHash("sha256").update(deliveryId).digest("hex").slice(0, 16)}`;
+}
+
+function eventClassFromPayload(payload: unknown): string {
+  const record = objectRecord(payload);
+  const type = String(record.type ?? "");
+  const action = String(record.action ?? "");
+  return [type, action].filter(Boolean).join(".") || "webhook.event";
+}
+
+function issueKeyFromPayload(payload: unknown): string | undefined {
+  const record = objectRecord(payload);
+  const data = objectRecord(record.data ?? payload);
+  const issue = objectRecord(data.issue);
+  const identifier = data.identifier ?? issue.identifier;
+  return typeof identifier === "string" && identifier ? identifier : undefined;
+}
+
+function recordStatus(
+  deps: WebhookHandlerDeps,
+  status: Omit<LinearWebhookStatus, "schemaVersion" | "observedAt">,
+): void {
+  try {
+    deps.onStatus?.({
+      schemaVersion: "linear.webhook_status.v1",
+      observedAt: new Date().toISOString(),
+      ...status,
+    });
+  } catch (err) {
+    deps.logger.error(`Webhook status recorder error: ${formatErrorMessage(err)}`);
+  }
+}
 
 function verifySignature(body: string, signature: string, secret: string): boolean {
   const expected = createHmac("sha256", secret).update(body).digest("hex");
@@ -72,6 +144,13 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
 
   return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     if (req.method !== "POST") {
+      recordStatus(deps, {
+        classification: "invalid_refusal",
+        state: "refused",
+        reason: "method_not_allowed",
+        eventClass: "webhook.method",
+        httpStatus: 405,
+      });
       res.writeHead(405, { Allow: "POST" });
       res.end("Method Not Allowed");
       return;
@@ -83,9 +162,23 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
     } catch (err) {
       const msg = formatErrorMessage(err);
       if (msg.includes("too large")) {
+        recordStatus(deps, {
+          classification: "invalid_refusal",
+          state: "refused",
+          reason: "payload_too_large",
+          eventClass: "webhook.body",
+          httpStatus: 413,
+        });
         res.writeHead(413);
         res.end("Payload Too Large");
       } else {
+        recordStatus(deps, {
+          classification: "unavailable_state",
+          state: "unavailable",
+          reason: "body_read_error",
+          eventClass: "webhook.body",
+          httpStatus: 500,
+        });
         res.writeHead(500);
         res.end("Internal Server Error");
       }
@@ -96,6 +189,13 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
     const secrets = Array.isArray(deps.webhookSecret) ? deps.webhookSecret : [deps.webhookSecret];
     const signatureValid = typeof signature === "string" && secrets.some((s) => verifySignature(rawBody, signature, s));
     if (!signatureValid) {
+      recordStatus(deps, {
+        classification: "invalid_refusal",
+        state: "refused",
+        reason: "invalid_signature",
+        eventClass: "webhook.signature",
+        httpStatus: 400,
+      });
       res.writeHead(400);
       res.end("Invalid signature");
       return;
@@ -104,13 +204,39 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
     let event: LinearWebhookPayload;
     try {
       const payload = JSON.parse(rawBody) as Record<string, unknown>;
-      const deliveryId = req.headers["linear-delivery"] as string | undefined;
+      const shape = validatePayloadShape(payload);
+      if (!shape.ok) {
+        recordStatus(deps, {
+          classification: "invalid_refusal",
+          state: "refused",
+          reason: "unsupported_event",
+          eventClass: eventClassFromPayload(payload),
+          issueKey: issueKeyFromPayload(payload),
+          httpStatus: 400,
+        });
+        deps.logger.info(`Webhook rejected: unsupported event action=${shape.action || "(missing)"} type=${shape.type || "(missing)"}`);
+        res.writeHead(400);
+        res.end("Unsupported event");
+        return;
+      }
+
+      const deliveryHeader = req.headers["linear-delivery"];
+      const deliveryId = typeof deliveryHeader === "string" ? deliveryHeader : undefined;
 
       // Prune expired entries periodically
       pruneDeliveries();
 
       if (deliveryId) {
         if (processedDeliveries.has(deliveryId)) {
+          recordStatus(deps, {
+            classification: "duplicate_replay",
+            state: "duplicate",
+            reason: "duplicate_delivery",
+            eventClass: eventClassFromPayload(payload),
+            issueKey: issueKeyFromPayload(payload),
+            deliveryHash: deliveryHash(deliveryId),
+            httpStatus: 200,
+          });
           deps.logger.info(`Duplicate delivery skipped: ${deliveryId}`);
           res.writeHead(200);
           res.end("OK");
@@ -125,16 +251,32 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
         // Some Linear webhook payloads (e.g. OAuth App events) place fields
         // directly on the top-level object instead of nesting under `data`.
         // Fall back to the full payload so downstream handlers still see data.
-        data: (payload.data as Record<string, unknown>) ?? payload,
+        data: objectRecord(payload.data ?? payload),
         updatedFrom: (payload.updatedFrom as Record<string, unknown>) ?? undefined,
         createdAt: String(payload.createdAt ?? ""),
       };
 
+      recordStatus(deps, {
+        classification: "accepted_ingress",
+        state: "accepted",
+        reason: "signature_valid",
+        eventClass: `${event.type}.${event.action}`,
+        issueKey: issueKeyFromPayload(payload),
+        ...(deliveryId ? { deliveryHash: deliveryHash(deliveryId) } : {}),
+        httpStatus: 200,
+      });
       deps.logger.info(`Linear webhook: ${event.action} ${event.type} (${String(event.data.id ?? "unknown")})`);
     } catch (err) {
+      recordStatus(deps, {
+        classification: "invalid_refusal",
+        state: "refused",
+        reason: "malformed_payload",
+        eventClass: "webhook.parse",
+        httpStatus: 400,
+      });
       deps.logger.error(`Webhook parse error: ${formatErrorMessage(err)}`);
-      res.writeHead(500);
-      res.end("Internal Server Error");
+      res.writeHead(400);
+      res.end("Malformed payload");
       return;
     }
 
@@ -146,6 +288,12 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
     try {
       deps.onEvent?.(event);
     } catch (err) {
+      recordStatus(deps, {
+        classification: "unavailable_state",
+        state: "unavailable",
+        reason: "event_handler_error",
+        eventClass: `${event.type}.${event.action}`,
+      });
       deps.logger.error(`Event handler error: ${formatErrorMessage(err)}`);
     }
   };

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -52,8 +52,8 @@ function objectRecord(value: unknown): Record<string, unknown> {
 
 function validatePayloadShape(payload: unknown): { ok: boolean; action: string; type: string } {
   const record = objectRecord(payload);
-  const action = String(record.action ?? "");
-  const type = String(record.type ?? "");
+  const action = typeof record.action === "string" ? record.action : "";
+  const type = typeof record.type === "string" ? record.type : "";
   const allowedActions = ALLOWED_EVENT_ACTIONS[type];
   if (!allowedActions || !allowedActions.has(action)) {
     return { ok: false, action, type };
@@ -96,11 +96,15 @@ function recordStatus(
 }
 
 function verifySignature(body: string, signature: string, secret: string): boolean {
-  const expected = createHmac("sha256", secret).update(body).digest("hex");
-  if (expected.length !== signature.length) {
+  if (!/^[a-f0-9]{64}$/i.test(signature)) {
     return false;
   }
-  return timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+  const expected = createHmac("sha256", secret).update(body).digest();
+  const provided = Buffer.from(signature, "hex");
+  if (expected.length !== provided.length) {
+    return false;
+  }
+  return timingSafeEqual(expected, provided);
 }
 
 function readBody(req: IncomingMessage): Promise<string> {

--- a/test/webhook-handler.test.ts
+++ b/test/webhook-handler.test.ts
@@ -127,7 +127,18 @@ describe("openclaw-linear manifest contract", () => {
       expect.objectContaining({ type: "string", minLength: 1 }),
       expect.objectContaining({ $ref: "#/$defs/secretRef" }),
     ]));
-    expect(manifest.configSchema.$defs.secretRef.required).toEqual(["source", "provider", "id"]);
+    expect(manifest.configSchema.$defs.secretRef.required).toEqual(
+      expect.arrayContaining(["source", "provider", "id"]),
+    );
+    expect(manifest.configSchema.$defs.secretRef.required).toHaveLength(3);
+    expect(manifest.configSchema.$defs.secretRef.properties.provider).toMatchObject({
+      type: "string",
+      minLength: 1,
+    });
+    expect(manifest.configSchema.$defs.secretRef.properties.id).toMatchObject({
+      type: "string",
+      minLength: 1,
+    });
     expect(manifest.configContracts.secretInputs.paths).toContainEqual({
       path: "webhookSecret",
       expected: "string",
@@ -211,6 +222,15 @@ describe("webhook-handler", () => {
     expect(res.body).toBe("Invalid signature");
   });
 
+  it("rejects non-hex signatures without throwing", async () => {
+    const body = JSON.stringify({ action: "update", type: "Issue", data: {}, createdAt: "" });
+    const req = makeReq(body, { "Linear-Signature": "\u00e9".repeat(64) });
+    const res = makeRes();
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toBe("Invalid signature");
+  });
+
   it("returns 400 when signature header is missing", async () => {
     const body = JSON.stringify({ action: "update", type: "Issue", data: {}, createdAt: "" });
     const req = makeReq(body, {});
@@ -275,11 +295,17 @@ describe("webhook-handler", () => {
       body: "{bad json",
       delivery: "delivery-malformed",
     });
+    const nonStringFields = await invoke(harnessHandler, {
+      body: issuePayload({ action: ["update"], type: ["Issue"] }),
+      delivery: "delivery-non-string-fields",
+    });
 
     expect(unsupported.statusCode).toBe(400);
     expect(unsupported.body).toBe("Unsupported event");
     expect(malformed.statusCode).toBe(400);
     expect(malformed.body).toBe("Malformed payload");
+    expect(nonStringFields.statusCode).toBe(400);
+    expect(nonStringFields.body).toBe("Unsupported event");
     expect(events).toHaveLength(0);
     expect(statuses).toEqual(expect.arrayContaining([
       expect.objectContaining({ reason: "unsupported_event", state: "refused" }),

--- a/test/webhook-handler.test.ts
+++ b/test/webhook-handler.test.ts
@@ -1,17 +1,23 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createHmac } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { createWebhookHandler } from "../src/webhook-handler.js";
+import { readFile } from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const SECRET = "test-webhook-secret";
+import { createWebhookHandler } from "../src/webhook-handler.js";
+
+function signingKey(): string {
+  return createHash("sha256").update("openclaw-linear-public-test-key").digest("hex");
+}
+
+const SECRET = signingKey();
 
 function makeLogger() {
   return { info: vi.fn(), error: vi.fn() };
 }
 
-function sign(body: string): string {
-  return createHmac("sha256", SECRET).update(body).digest("hex");
+function sign(body: string, secret = SECRET): string {
+  return createHmac("sha256", secret).update(body).digest("hex");
 }
 
 function makeReq(
@@ -24,7 +30,6 @@ function makeReq(
   req.headers = Object.fromEntries(
     Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]),
   );
-  // Emit body asynchronously
   process.nextTick(() => {
     req.emit("data", Buffer.from(body));
     req.emit("end");
@@ -32,19 +37,103 @@ function makeReq(
   return req;
 }
 
-function makeRes(): ServerResponse & { body: string; statusCode: number } {
+function makeRes(): ServerResponse & {
+  body: string;
+  headers?: unknown;
+  statusCode: number;
+} {
   const res = {
     statusCode: 200,
+    headers: undefined as unknown,
     body: "",
-    writeHead(code: number) {
+    writeHead(code: number, headers?: unknown) {
       res.statusCode = code;
+      res.headers = headers;
     },
     end(data?: string) {
       res.body = data ?? "";
     },
-  } as unknown as ServerResponse & { body: string; statusCode: number };
+  } as unknown as ServerResponse & { body: string; headers?: unknown; statusCode: number };
   return res;
 }
+
+function issuePayload(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    action: "update",
+    type: "Issue",
+    data: {
+      id: "issue-id",
+      identifier: "OC-T",
+      title: "Test issue",
+    },
+    createdAt: "2026-06-08T00:00:00.000Z",
+    ...overrides,
+  });
+}
+
+function createHarness() {
+  const statuses: unknown[] = [];
+  const events: unknown[] = [];
+  const logs: string[] = [];
+  const logger = {
+    info: vi.fn((message: string) => logs.push(message)),
+    error: vi.fn((message: string) => logs.push(message)),
+  };
+  const handler = createWebhookHandler({
+    webhookSecret: SECRET,
+    onStatus: (status) => statuses.push(status),
+    onEvent: (event) => events.push(event),
+    logger,
+  });
+  return { events, handler, logger, logs, statuses };
+}
+
+async function invoke(
+  handler: ReturnType<typeof createWebhookHandler>,
+  {
+    body = issuePayload(),
+    delivery = "delivery-1",
+    secret = SECRET,
+    signature,
+  }: {
+    body?: string;
+    delivery?: string;
+    secret?: string;
+    signature?: string;
+  } = {},
+) {
+  const req = makeReq(body, {
+    ...(delivery ? { "Linear-Delivery": delivery } : {}),
+    ...(signature === undefined
+      ? { "Linear-Signature": sign(body, secret) }
+      : signature
+        ? { "Linear-Signature": signature }
+        : {}),
+  });
+  const res = makeRes();
+  await handler(req, res);
+  return res;
+}
+
+describe("openclaw-linear manifest contract", () => {
+  it("allows webhookSecret as either a string or a SecretRef and declares the runtime secret input path", async () => {
+    const manifest = JSON.parse(
+      await readFile(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
+    );
+    const webhookSecret = manifest.configSchema.properties.webhookSecret;
+    const variants = webhookSecret.anyOf;
+
+    expect(variants).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "string", minLength: 1 }),
+      expect.objectContaining({ $ref: "#/$defs/secretRef" }),
+    ]));
+    expect(manifest.configSchema.$defs.secretRef.required).toEqual(["source", "provider", "id"]);
+    expect(manifest.configContracts.secretInputs.paths).toContainEqual({
+      path: "webhookSecret",
+      expected: "string",
+    });
+  });
+});
 
 describe("webhook-handler", () => {
   let logger: ReturnType<typeof makeLogger>;
@@ -53,6 +142,33 @@ describe("webhook-handler", () => {
   beforeEach(() => {
     logger = makeLogger();
     handler = createWebhookHandler({ webhookSecret: SECRET, logger });
+  });
+
+  it("accepts a valid HMAC delivery without exposing signing material", async () => {
+    const { events, handler: harnessHandler, logs, statuses } = createHarness();
+    const body = issuePayload();
+    const signature = sign(body);
+    const res = await invoke(harnessHandler, {
+      body,
+      delivery: "delivery-valid",
+      signature,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ action: "update", type: "Issue" });
+    expect(statuses).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        classification: "accepted_ingress",
+        state: "accepted",
+        reason: "signature_valid",
+        deliveryHash: expect.stringMatching(/^sha256:[a-f0-9]{16}$/),
+      }),
+    ]));
+    expect(JSON.stringify(statuses)).not.toContain(SECRET);
+    expect(JSON.stringify(statuses)).not.toContain(signature);
+    expect(logs.join("\n")).not.toContain(SECRET);
+    expect(logs.join("\n")).not.toContain(signature);
   });
 
   it("returns 200 for valid signature", async () => {
@@ -72,6 +188,20 @@ describe("webhook-handler", () => {
     );
   });
 
+  it("refuses unsigned and invalid deliveries without dispatching events", async () => {
+    const { events, handler: harnessHandler, statuses } = createHarness();
+    const unsigned = await invoke(harnessHandler, { signature: "" });
+    const invalid = await invoke(harnessHandler, {
+      delivery: "delivery-invalid",
+      signature: "bad-signature",
+    });
+
+    expect(unsigned.statusCode).toBe(400);
+    expect(invalid.statusCode).toBe(400);
+    expect(events).toHaveLength(0);
+    expect(statuses.filter((status) => (status as { reason?: string }).reason === "invalid_signature")).toHaveLength(2);
+  });
+
   it("returns 400 for invalid signature", async () => {
     const body = JSON.stringify({ action: "update", type: "Issue", data: {}, createdAt: "" });
     const req = makeReq(body, { "Linear-Signature": "invalidsignature" });
@@ -89,6 +219,25 @@ describe("webhook-handler", () => {
     expect(res.statusCode).toBe(400);
   });
 
+  it("records duplicate delivery replay without dispatching the event twice", async () => {
+    const { events, handler: harnessHandler, statuses } = createHarness();
+
+    const first = await invoke(harnessHandler, { delivery: "delivery-replay" });
+    const second = await invoke(harnessHandler, { delivery: "delivery-replay" });
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(200);
+    expect(events).toHaveLength(1);
+    expect(statuses).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        classification: "duplicate_replay",
+        state: "duplicate",
+        reason: "duplicate_delivery",
+        deliveryHash: expect.stringMatching(/^sha256:[a-f0-9]{16}$/),
+      }),
+    ]));
+  });
+
   it("detects and skips duplicate deliveries", async () => {
     const body = JSON.stringify({
       action: "update",
@@ -101,13 +250,11 @@ describe("webhook-handler", () => {
       "Linear-Delivery": "delivery-dup-test-123",
     };
 
-    // First request
     const req1 = makeReq(body, headers);
     const res1 = makeRes();
     await handler(req1, res1);
     expect(res1.statusCode).toBe(200);
 
-    // Second request with same delivery ID
     const req2 = makeReq(body, headers);
     const res2 = makeRes();
     await handler(req2, res2);
@@ -117,12 +264,36 @@ describe("webhook-handler", () => {
     );
   });
 
-  it("returns 500 for malformed JSON payload", async () => {
+  it("fails closed for unsupported and malformed payloads", async () => {
+    const { events, handler: harnessHandler, statuses } = createHarness();
+    const unsupportedBody = issuePayload({ action: "archive", type: "UnknownType" });
+    const unsupported = await invoke(harnessHandler, {
+      body: unsupportedBody,
+      delivery: "delivery-unsupported",
+    });
+    const malformed = await invoke(harnessHandler, {
+      body: "{bad json",
+      delivery: "delivery-malformed",
+    });
+
+    expect(unsupported.statusCode).toBe(400);
+    expect(unsupported.body).toBe("Unsupported event");
+    expect(malformed.statusCode).toBe(400);
+    expect(malformed.body).toBe("Malformed payload");
+    expect(events).toHaveLength(0);
+    expect(statuses).toEqual(expect.arrayContaining([
+      expect.objectContaining({ reason: "unsupported_event", state: "refused" }),
+      expect.objectContaining({ reason: "malformed_payload", state: "refused" }),
+    ]));
+  });
+
+  it("returns 400 for malformed JSON payload", async () => {
     const body = "not valid json {{{";
     const req = makeReq(body, { "Linear-Signature": sign(body) });
     const res = makeRes();
     await handler(req, res);
-    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toBe("Malformed payload");
     expect(logger.error).toHaveBeenCalled();
   });
 
@@ -149,7 +320,6 @@ describe("webhook-handler", () => {
     const res = makeRes();
     await h(req, res);
 
-    // Handler returns 200 despite onEvent throwing
     expect(res.statusCode).toBe(200);
     expect(res.body).toBe("OK");
     expect(onEvent).toHaveBeenCalled();
@@ -211,7 +381,6 @@ describe("webhook-handler", () => {
       data: { id: "issue-multi" },
       createdAt: "2026-01-01T00:00:00Z",
     });
-    // Sign with SECRET (the third secret)
     const req = makeReq(body, { "Linear-Signature": sign(body) });
     const res = makeRes();
     await h(req, res);
@@ -228,23 +397,21 @@ describe("webhook-handler", () => {
       data: { id: "issue-bad" },
       createdAt: "2026-01-01T00:00:00Z",
     });
-    // Sign with SECRET which is NOT in the array
     const req = makeReq(body, { "Linear-Signature": sign(body) });
     const res = makeRes();
     await h(req, res);
     expect(res.statusCode).toBe(400);
   });
 
-  it("falls back to full payload when data field is missing", async () => {
+  it("falls back to full payload when data field is missing for an allowed event", async () => {
     const onEvent = vi.fn();
     const h = createWebhookHandler({ webhookSecret: SECRET, logger, onEvent });
 
-    // Simulate an OAuth App webhook that has no nested `data` field
     const body = JSON.stringify({
       action: "create",
-      type: "AgentSession",
-      id: "session-1",
-      agentId: "agent-1",
+      type: "Comment",
+      id: "comment-1",
+      body: "hello",
       createdAt: "2026-01-01T00:00:00Z",
     });
     const req = makeReq(body, { "Linear-Signature": sign(body) });
@@ -254,8 +421,7 @@ describe("webhook-handler", () => {
     expect(res.statusCode).toBe(200);
     expect(onEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        // data should be the full payload since payload.data is undefined
-        data: expect.objectContaining({ id: "session-1", agentId: "agent-1" }),
+        data: expect.objectContaining({ id: "comment-1", body: "hello" }),
       }),
     );
   });
@@ -269,7 +435,6 @@ describe("webhook-handler", () => {
 
     const res = makeRes();
 
-    // Send 2MB payload in chunks
     process.nextTick(() => {
       const chunk = Buffer.alloc(1024 * 1024 + 1, "x");
       req.emit("data", chunk);


### PR DESCRIPTION
## Summary

Restores the durable source-package copy of the webhook security behavior that was only present in the installed OpenClaw Linear artifact.

- Adds the `webhookSecret` string-or-SecretRef manifest contract plus runtime secret input declaration.
- Adds webhook status reporting for accepted ingress, duplicate replay, invalid refusals, and unavailable handler states.
- Adds source tests covering HMAC acceptance/refusal, duplicate replay, unsupported/malformed fail-closed behavior, SecretRef manifest shape, and no signing-material exposure.

## Validation

Evidence root: `/home/ubuntu/runnerd-service-checkout-oc52-fixed/runs/20260608T141621Z-full-approval-blocker-resolution/`

Current reviewed head: `cb5e2225542cb70b551eeab80d481add7baa07ff`.

- `pr27-reviewfix-final-npm-build.txt`: `npm run build` passed.
- `pr27-reviewfix-final-npm-test.txt`: `npm test` passed, 12 files / 208 tests.
- `pr27-reviewfix-final-git-diff-check.txt`: `git diff --check` passed.
- `pr27-reviewfix-thread-readback.json`: visible review threads resolved.
- `continue7-pr27-current-readback.json`: PR remains open, ready, mergeable, CodeRabbit `SUCCESS`.

## Merge Blocker

Source is accepted and ready to merge, but the available identities do not have merge permission on `stepandel/openclaw-linear`.

- `continue-pr27-merge-attempt.txt`: CLI merge lacks `MergePullRequest` permission.
- `continue-pr27-github-app-merge-attempt.json`: GitHub app merge gets 403 `Resource not accessible by integration`.
- `continue-pr27-auto-merge-attempt.json`: auto-merge is unavailable for this repository.
- `continue5-pr27-add-reviewer-stepandel.txt`: reviewer request also lacks `RequestReviewsByLogin` permission.
- `continue4-ruleset-13011044.json`: active default-branch rules only block deletion and non-fast-forward updates, so this is a repository permission blocker, not a failing required status check.

Maintainer merge command:

```bash
gh pr merge 27 --repo stepandel/openclaw-linear --merge --match-head-commit cb5e2225542cb70b551eeab80d481add7baa07ff
```

Next action: `@stepandel` or another maintainer with merge permission on `stepandel/openclaw-linear` should merge this PR at the current head. Local installed-extension update remains deferred until upstream merge, per `pr27-local-install-decision.md`.

## Notes

This does not expose runtime secrets and does not change any Runner authority, worker route, Linear writeback path, or installed OpenClaw service configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook status reporting with detailed outcome tracking for webhook handling events.
  * Webhook secret configuration now supports both direct string values and structured provider references.

* **Bug Fixes**
  * Improved webhook validation with proper error responses for invalid and malformed payloads.
  * Enhanced duplicate delivery detection.

* **Documentation**
  * Updated README with expanded webhook secret configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->